### PR TITLE
feat: add `getBalance` to `Wallet` base class

### DIFF
--- a/packages/sdk/src/wallet/PrivyWallet.ts
+++ b/packages/sdk/src/wallet/PrivyWallet.ts
@@ -25,7 +25,6 @@ export class PrivyWallet extends Wallet {
   public signer!: LocalAccount
   public readonly address: Address
   private privyClient: PrivyClient
-  private chainManager: ChainManager
 
   /**
    * Create a new Privy wallet provider
@@ -39,10 +38,9 @@ export class PrivyWallet extends Wallet {
     address: Address,
     chainManager: ChainManager,
   ) {
-    super()
+    super(chainManager)
     this.privyClient = privyClient
     this.walletId = walletId
-    this.chainManager = chainManager
     this.address = address
   }
 

--- a/packages/sdk/src/wallet/base/SmartWallet.ts
+++ b/packages/sdk/src/wallet/base/SmartWallet.ts
@@ -6,7 +6,6 @@ import type {
   LendTransaction,
   TransactionData,
 } from '@/types/lend.js'
-import type { TokenBalance } from '@/types/token.js'
 import type { AssetIdentifier } from '@/utils/assets.js'
 import { Wallet } from '@/wallet/base/Wallet.js'
 
@@ -18,13 +17,6 @@ export abstract class SmartWallet extends Wallet {
   async walletClient(_chainId: SupportedChainId): Promise<WalletClient> {
     throw new Error('walletClient is not supported on SmartWallet')
   }
-
-  /**
-   * Get all token balances for this wallet
-   * @description Retrieves balances for all supported tokens held by this smart wallet.
-   * @returns Promise resolving to an array of token balances with amounts and metadata
-   */
-  abstract getBalance(): Promise<TokenBalance[]>
 
   // TODO: add addSigner method
   // TODO: add removeSigner method

--- a/packages/sdk/src/wallet/base/Wallet.spec.ts
+++ b/packages/sdk/src/wallet/base/Wallet.spec.ts
@@ -1,0 +1,80 @@
+import type { Address, LocalAccount, WalletClient } from 'viem'
+import { unichain } from 'viem/chains'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+import type { ChainManager } from '@/services/ChainManager.js'
+import { fetchERC20Balance, fetchETHBalance } from '@/services/tokenBalance.js'
+import { SUPPORTED_TOKENS } from '@/supported/tokens.js'
+import { MockChainManager } from '@/test/MockChainManager.js'
+import { getRandomAddress } from '@/test/utils.js'
+import { Wallet } from '@/wallet/base/Wallet.js'
+
+vi.mock('@/services/tokenBalance.js', async () => {
+  return {
+    fetchETHBalance: vi.fn().mockResolvedValue({} as unknown),
+    fetchERC20Balance: vi.fn().mockResolvedValue({} as unknown),
+  }
+})
+
+class TestWallet extends Wallet {
+  public readonly address: Address
+  public readonly signer: LocalAccount
+
+  constructor(
+    chainManager: ChainManager,
+    address: Address,
+    signer: LocalAccount,
+  ) {
+    super(chainManager)
+    this.address = address
+    this.signer = signer
+  }
+
+  // Not used in these tests
+  async walletClient(_chainId: SupportedChainId): Promise<WalletClient> {
+    return {} as unknown as WalletClient
+  }
+}
+
+describe('Wallet (base)', () => {
+  const chainManager = new MockChainManager({
+    supportedChains: [unichain.id],
+  }) as unknown as ChainManager
+
+  const address = getRandomAddress()
+  const signer = { address } as unknown as LocalAccount
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('getBalance fetches ETH and ERC20 balances for supported tokens', async () => {
+    const wallet = new TestWallet(chainManager, address, signer)
+
+    const result = await wallet.getBalance()
+
+    expect(result).toBeTruthy()
+    expect(fetchETHBalance).toHaveBeenCalledTimes(1)
+    expect(fetchETHBalance).toHaveBeenCalledWith(chainManager, address)
+
+    const tokenCount = Object.values(SUPPORTED_TOKENS).length
+    expect(fetchERC20Balance).toHaveBeenCalledTimes(tokenCount)
+
+    // Ensure each call used the same chainManager and address
+    for (const call of (fetchERC20Balance as Mock).mock.calls) {
+      expect(call[0]).toBe(chainManager)
+      expect(call[1]).toBe(address)
+      expect(call[2]).toBeTruthy()
+    }
+  })
+
+  it('getBalance propagates errors from underlying fetchers', async () => {
+    vi.mocked(fetchETHBalance).mockRejectedValueOnce(new Error('rpc error'))
+
+    const wallet = new TestWallet(chainManager, address, signer)
+
+    await expect(wallet.getBalance()).rejects.toThrow('rpc error')
+  })
+})


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/verbs/issues/91

## Changes
- Add ChainManager to base `Wallet` and implement `getBalance()`:
  - Fetches ETH and all `SUPPORTED_TOKENS` via `fetchETHBalance`/`fetchERC20Balance`
  - Standardizes balance logic across wallet types
- Remove per-class balance code:
  - Drop `getBalance()` from `DefaultSmartWallet`
  - Remove `abstract getBalance()` from `SmartWallet` (now inherited)