### PR TITLE
feat: introduce `HostedWalletProviderRegistry`

### DIFF
--- a/packages/demo/backend/src/config/verbs.ts
+++ b/packages/demo/backend/src/config/verbs.ts
@@ -12,7 +12,12 @@ export function createVerbsConfig(): VerbsConfig {
       hostedWalletConfig: {
         provider: {
           type: 'privy',
-          privyClient: new PrivyClient(env.PRIVY_APP_ID, env.PRIVY_APP_SECRET),
+          config: {
+            privyClient: new PrivyClient(
+              env.PRIVY_APP_ID,
+              env.PRIVY_APP_SECRET,
+            ),
+          },
         },
       },
       smartWalletConfig: {

--- a/packages/sdk/src/types/verbs.ts
+++ b/packages/sdk/src/types/verbs.ts
@@ -1,6 +1,5 @@
-import type { PrivyClient } from '@privy-io/server-auth'
-
 import type { ChainConfig } from '@/types/chain.js'
+import type { HostedProviderUnion } from '@/wallet/providers/hostedProvider.types.js'
 
 import type { LendConfig } from './lend.js'
 
@@ -34,7 +33,7 @@ export type WalletConfig = {
  */
 export interface HostedWalletConfig {
   /** Wallet provider for account creation, management, and signing */
-  provider: HostedWalletProviderConfig
+  provider: HostedProviderUnion
 }
 
 /**
@@ -58,18 +57,4 @@ export type SmartWalletProvider = DefaultSmartWalletProvider
  */
 export interface DefaultSmartWalletProvider {
   type: 'default'
-}
-
-/**
- * Hosted wallet provider configurations
- * @description Union type supporting multiple hosted wallet providers
- */
-export type HostedWalletProviderConfig = PrivyHostedWalletProviderConfig
-
-/** Privy hosted wallet provider configuration */
-export interface PrivyHostedWalletProviderConfig {
-  /** Hosted wallet provider type */
-  type: 'privy'
-  /** Privy client instance */
-  privyClient: PrivyClient
 }

--- a/packages/sdk/src/verbs.test.ts
+++ b/packages/sdk/src/verbs.test.ts
@@ -27,10 +27,12 @@ describe('Verbs SDK - System Tests', () => {
             hostedWalletConfig: {
               provider: {
                 type: 'privy',
-                privyClient: createMockPrivyClient(
-                  'test-app-id',
-                  'test-app-secret',
-                ),
+                config: {
+                  privyClient: createMockPrivyClient(
+                    'test-app-id',
+                    'test-app-secret',
+                  ),
+                },
               },
             },
             smartWalletConfig: {
@@ -103,10 +105,12 @@ describe('Verbs SDK - System Tests', () => {
             hostedWalletConfig: {
               provider: {
                 type: 'privy',
-                privyClient: createMockPrivyClient(
-                  'test-app-id',
-                  'test-app-secret',
-                ),
+                config: {
+                  privyClient: createMockPrivyClient(
+                    'test-app-id',
+                    'test-app-secret',
+                  ),
+                },
               },
             },
             smartWalletConfig: {
@@ -150,10 +154,12 @@ describe('Verbs SDK - System Tests', () => {
             hostedWalletConfig: {
               provider: {
                 type: 'privy',
-                privyClient: createMockPrivyClient(
-                  'test-app-id',
-                  'test-app-secret',
-                ),
+                config: {
+                  privyClient: createMockPrivyClient(
+                    'test-app-id',
+                    'test-app-secret',
+                  ),
+                },
               },
             },
             smartWalletConfig: {
@@ -187,10 +193,12 @@ describe('Verbs SDK - System Tests', () => {
           hostedWalletConfig: {
             provider: {
               type: 'privy',
-              privyClient: createMockPrivyClient(
-                'test-app-id',
-                'test-app-secret',
-              ),
+              config: {
+                privyClient: createMockPrivyClient(
+                  'test-app-id',
+                  'test-app-secret',
+                ),
+              },
             },
           },
           smartWalletConfig: {
@@ -222,10 +230,12 @@ describe('Verbs SDK - System Tests', () => {
           hostedWalletConfig: {
             provider: {
               type: 'privy',
-              privyClient: createMockPrivyClient(
-                'test-app-id',
-                'test-app-secret',
-              ),
+              config: {
+                privyClient: createMockPrivyClient(
+                  'test-app-id',
+                  'test-app-secret',
+                ),
+              },
             },
           },
           smartWalletConfig: {

--- a/packages/sdk/src/verbs.ts
+++ b/packages/sdk/src/verbs.ts
@@ -5,7 +5,7 @@ import type { VerbsConfig } from '@/types/verbs.js'
 import type { HostedWalletProvider } from '@/wallet/providers/base/HostedWalletProvider.js'
 import type { SmartWalletProvider } from '@/wallet/providers/base/SmartWalletProvider.js'
 import { DefaultSmartWalletProvider } from '@/wallet/providers/DefaultSmartWalletProvider.js'
-import { PrivyHostedWalletProvider } from '@/wallet/providers/PrivyHostedWalletProvider.js'
+import { HostedWalletProviderRegistry } from '@/wallet/providers/HostedWalletProviderRegistry.js'
 import { WalletNamespace } from '@/wallet/WalletNamespace.js'
 import { WalletProvider } from '@/wallet/WalletProvider.js'
 
@@ -19,9 +19,11 @@ export class Verbs {
   private lendProvider?: LendProvider
   private hostedWalletProvider!: HostedWalletProvider
   private smartWalletProvider!: SmartWalletProvider
+  private hostedWalletProviderRegistry: HostedWalletProviderRegistry
 
   constructor(config: VerbsConfig) {
     this.chainManager = new ChainManager(config.chains)
+    this.hostedWalletProviderRegistry = new HostedWalletProviderRegistry()
 
     // Create lending provider if configured
     if (config.lend) {
@@ -57,16 +59,19 @@ export class Verbs {
    * @returns WalletProvider instance
    */
   private createWalletProvider(config: VerbsConfig['wallet']) {
-    if (config.hostedWalletConfig.provider.type === 'privy') {
-      this.hostedWalletProvider = new PrivyHostedWalletProvider(
-        config.hostedWalletConfig.provider.privyClient,
-        this.chainManager,
-      )
-    } else {
+    const hostedWalletProviderConfig = config.hostedWalletConfig.provider
+    const factory = this.hostedWalletProviderRegistry.getFactory(
+      hostedWalletProviderConfig.type,
+    )
+    if (!factory.validateOptions(hostedWalletProviderConfig.config)) {
       throw new Error(
-        `Unsupported hosted wallet provider: ${config.hostedWalletConfig.provider.type}`,
+        `Invalid options for hosted wallet provider: ${hostedWalletProviderConfig.type}`,
       )
     }
+    this.hostedWalletProvider = factory.create(
+      { chainManager: this.chainManager },
+      hostedWalletProviderConfig.config,
+    )
 
     if (
       !config.smartWalletConfig ||

--- a/packages/sdk/src/wallet/providers/HostedWalletProviderRegistry.spec.ts
+++ b/packages/sdk/src/wallet/providers/HostedWalletProviderRegistry.spec.ts
@@ -1,0 +1,56 @@
+import type { PrivyClient } from '@privy-io/server-auth'
+import { unichain } from 'viem/chains'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChainManager } from '@/services/ChainManager.js'
+import { MockChainManager } from '@/test/MockChainManager.js'
+import { createMockPrivyClient } from '@/test/MockPrivyClient.js'
+import { HostedWalletProviderRegistry } from '@/wallet/providers/HostedWalletProviderRegistry.js'
+import { PrivyHostedWalletProvider } from '@/wallet/providers/PrivyHostedWalletProvider.js'
+
+describe('HostedWalletProviderRegistry', () => {
+  const mockChainManager = new MockChainManager({
+    supportedChains: [unichain.id],
+  }) as unknown as ChainManager
+  let mockPrivyClient: PrivyClient
+
+  beforeEach(() => {
+    mockPrivyClient = createMockPrivyClient('test-app-id', 'test-app-secret')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns privy factory and validates options', () => {
+    const registry = new HostedWalletProviderRegistry()
+    const factory = registry.getFactory('privy')
+
+    expect(factory.type).toBe('privy')
+    expect(factory.validateOptions?.({ privyClient: mockPrivyClient })).toBe(
+      true,
+    )
+    // Invalid shape should not pass validation
+    expect(factory.validateOptions?.({})).toBe(false)
+  })
+
+  it('creates a PrivyHostedWalletProvider instance', () => {
+    const registry = new HostedWalletProviderRegistry()
+    const factory = registry.getFactory('privy')
+
+    const provider = factory.create(
+      { chainManager: mockChainManager },
+      { privyClient: mockPrivyClient },
+    )
+
+    expect(provider).toBeInstanceOf(PrivyHostedWalletProvider)
+  })
+
+  it('throws for unknown provider type', () => {
+    const registry = new HostedWalletProviderRegistry()
+    // @ts-expect-error: testing runtime error for unknown type
+    expect(() => registry.getFactory('unknown')).toThrow(
+      'Unknown hosted wallet provider: unknown',
+    )
+  })
+})

--- a/packages/sdk/src/wallet/providers/HostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/providers/HostedWalletProviderRegistry.ts
@@ -1,0 +1,40 @@
+import type {
+  HostedProviderFactory,
+  HostedProviderType,
+  PrivyOptions,
+} from '@/wallet/providers/hostedProvider.types.js'
+import { PrivyHostedWalletProvider } from '@/wallet/providers/PrivyHostedWalletProvider.js'
+
+export class HostedWalletProviderRegistry {
+  private readonly registry = new Map<
+    HostedProviderType,
+    HostedProviderFactory
+  >()
+
+  public constructor() {
+    this.register<'privy'>({
+      type: 'privy',
+      validateOptions(options): options is PrivyOptions {
+        return Boolean((options as PrivyOptions)?.privyClient)
+      },
+      create({ chainManager }, options) {
+        return new PrivyHostedWalletProvider(options.privyClient, chainManager)
+      },
+    })
+  }
+
+  getFactory<TType extends HostedProviderType>(type: TType) {
+    const factory = this.registry.get(type) as
+      | HostedProviderFactory<TType>
+      | undefined
+    if (!factory) throw new Error(`Unknown hosted wallet provider: ${type}`)
+    return factory
+  }
+
+  private register<T extends HostedProviderType>(
+    factory: HostedProviderFactory<T>,
+  ) {
+    if (!this.registry.has(factory.type))
+      this.registry.set(factory.type, factory)
+  }
+}

--- a/packages/sdk/src/wallet/providers/hostedProvider.types.ts
+++ b/packages/sdk/src/wallet/providers/hostedProvider.types.ts
@@ -1,0 +1,31 @@
+import type { PrivyClient } from '@privy-io/server-auth'
+
+import type { ChainManager } from '@/services/ChainManager.js'
+import type { HostedWalletProvider } from '@/wallet/providers/base/HostedWalletProvider.js'
+
+export interface PrivyOptions {
+  privyClient: PrivyClient
+}
+
+export interface HostedProviderConfigMap {
+  privy: PrivyOptions
+}
+
+export type HostedProviderType = keyof HostedProviderConfigMap
+
+export interface HostedProviderDeps {
+  chainManager: ChainManager
+}
+
+export interface HostedProviderFactory<
+  TType extends HostedProviderType = HostedProviderType,
+  TOptions = HostedProviderConfigMap[TType],
+> {
+  type: TType
+  validateOptions(options: unknown): options is TOptions
+  create(deps: HostedProviderDeps, options: TOptions): HostedWalletProvider
+}
+
+export type HostedProviderUnion = {
+  [K in HostedProviderType]: { type: K; config: HostedProviderConfigMap[K] }
+}[HostedProviderType]


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/verbs/issues/101

## Summary
Introduce a pluggable Hosted Wallet Provider architecture with a typed registry and a discriminated provider config. This decouples provider creation from the SDK core, enabling new providers to register with minimal changes.

## Key changes
- Add `HostedWalletProviderRegistry`
  - Central registry mapping provider type → factory
- Update Verbs SDK to use `HostedWalletProviderRegistry` for registering the `hostedWalletProvider`

## Benefits
- Clear separation of concerns; core remains stable while providers self-register
- Strong compile-time typing for provider configs
- Simplified path to add new providers (register factory + options guard)
