### PR TITLE
refactor(wallets): create environment scoped wallet types and make core wallet types environment agnostic

### DIFF
--- a/packages/demo/backend/src/config/verbs.ts
+++ b/packages/demo/backend/src/config/verbs.ts
@@ -1,17 +1,14 @@
-import {
-  createVerbs,
-  type Verbs,
-  type VerbsConfig,
-} from '@eth-optimism/verbs-sdk/node'
+import type { NodeVerbsConfig } from '@eth-optimism/verbs-sdk/node'
+import { createVerbs } from '@eth-optimism/verbs-sdk/node'
 import { PrivyClient } from '@privy-io/server-auth'
 import { baseSepolia, unichain } from 'viem/chains'
 
 import { env } from './env.js'
 import { GauntletUSDC, MetaMorphoUSDC, USDCDemoVault } from './markets.js'
 
-let verbsInstance: Verbs<'privy'>
+let verbsInstance: ReturnType<typeof createVerbs<'privy'>>
 
-export function createVerbsConfig(): VerbsConfig<'privy'> {
+export function createVerbsConfig(): NodeVerbsConfig<'privy'> {
   return {
     wallet: {
       hostedWalletConfig: {
@@ -59,7 +56,7 @@ export function createVerbsConfig(): VerbsConfig<'privy'> {
   }
 }
 
-export function initializeVerbs(config?: VerbsConfig<'privy'>): void {
+export function initializeVerbs(config?: NodeVerbsConfig<'privy'>): void {
   const verbsConfig = config || createVerbsConfig()
   verbsInstance = createVerbs(verbsConfig)
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -66,7 +66,7 @@
     "@dynamic-labs/ethereum": ">=4.31.4",
     "@dynamic-labs/wallet-connector-core": ">=4.31.4",
     "@dynamic-labs/waas-evm": ">=4.31.4",
-    "@privy-io/server-auth": ">=1.28.0",
+    "@privy-io/server-auth": ">=1.31.1",
     "@turnkey/core": ">=1.1.1",
     "@turnkey/http": ">=3.12.1",
     "@turnkey/sdk-server": ">=4.9.1",

--- a/packages/sdk/src/index.node.ts
+++ b/packages/sdk/src/index.node.ts
@@ -1,3 +1,4 @@
 export * from '@/index.js'
+export type { NodeVerbsConfig } from '@/nodeVerbsFactory.js'
 export { createVerbs } from '@/nodeVerbsFactory.js'
 export * from '@/wallet/node/index.js'

--- a/packages/sdk/src/index.react.ts
+++ b/packages/sdk/src/index.react.ts
@@ -1,3 +1,4 @@
 export * from '@/index.js'
+export type { ReactVerbsConfig } from '@/reactVerbsFactory.js'
 export { createVerbs } from '@/reactVerbsFactory.js'
 export * from '@/wallet/react/index.js'

--- a/packages/sdk/src/nodeVerbsFactory.ts
+++ b/packages/sdk/src/nodeVerbsFactory.ts
@@ -1,7 +1,19 @@
 import type { VerbsConfig } from '@/types/verbs.js'
 import { Verbs } from '@/verbs.js'
-import type { NodeHostedProviderType } from '@/wallet/core/providers/hosted/types/index.js'
 import { NodeHostedWalletProviderRegistry } from '@/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.js'
+import type {
+  NodeHostedWalletProvidersSchema,
+  NodeOptionsMap,
+  NodeProviderTypes,
+} from '@/wallet/node/providers/hosted/types/index.js'
+
+/**
+ * Node Verbs configuration
+ * @description Configuration object for initializing the Verbs SDK in Node
+ */
+export type NodeVerbsConfig<
+  HostedWalletProviderType extends NodeProviderTypes,
+> = VerbsConfig<HostedWalletProviderType, NodeOptionsMap>
 
 /**
  * Creates a Node environment Verbs factory
@@ -12,10 +24,14 @@ import { NodeHostedWalletProviderRegistry } from '@/wallet/node/providers/hosted
  * @param config Verbs configuration
  * @returns Verbs instance using the NodeHostedWalletProviderRegistry
  */
-export function createVerbs<T extends NodeHostedProviderType>(
-  config: VerbsConfig<T>,
+export function createVerbs<HostedWalletProviderType extends NodeProviderTypes>(
+  config: NodeVerbsConfig<HostedWalletProviderType>,
 ) {
-  return new Verbs<T>(config, {
+  return new Verbs<
+    NodeHostedWalletProvidersSchema['providerTypes'],
+    NodeHostedWalletProvidersSchema,
+    HostedWalletProviderType
+  >(config, {
     hostedWalletProviderRegistry: new NodeHostedWalletProviderRegistry(),
   })
 }

--- a/packages/sdk/src/reactVerbsFactory.ts
+++ b/packages/sdk/src/reactVerbsFactory.ts
@@ -1,6 +1,19 @@
 import type { VerbsConfig } from '@/types/verbs.js'
 import { Verbs } from '@/verbs.js'
+import type {
+  ReactHostedWalletProvidersSchema,
+  ReactOptionsMap,
+  ReactProviderTypes,
+} from '@/wallet/react/providers/hosted/types/index.js'
 import { ReactHostedWalletProviderRegistry } from '@/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.js'
+
+/**
+ * React Verbs configuration
+ * @description Configuration object for initializing the Verbs SDK in React
+ */
+export type ReactVerbsConfig<
+  HostedWalletProviderType extends ReactProviderTypes,
+> = VerbsConfig<HostedWalletProviderType, ReactOptionsMap>
 
 /**
  * Creates a React/browser environment Verbs factory
@@ -11,8 +24,14 @@ import { ReactHostedWalletProviderRegistry } from '@/wallet/react/providers/regi
  * @param config Verbs configuration
  * @returns Verbs instance using the ReactHostedWalletProviderRegistry
  */
-export function createVerbs(config: VerbsConfig<'dynamic'>) {
-  return new Verbs(config, {
+export function createVerbs<
+  HostedWalletProviderType extends ReactProviderTypes,
+>(config: ReactVerbsConfig<HostedWalletProviderType>) {
+  return new Verbs<
+    ReactHostedWalletProvidersSchema['providerTypes'],
+    ReactHostedWalletProvidersSchema,
+    HostedWalletProviderType
+  >(config, {
     hostedWalletProviderRegistry: new ReactHostedWalletProviderRegistry(),
   })
 }

--- a/packages/sdk/src/types/verbs.ts
+++ b/packages/sdk/src/types/verbs.ts
@@ -1,8 +1,5 @@
 import type { ChainConfig } from '@/types/chain.js'
-import type {
-  HostedProviderType,
-  ProviderSpec,
-} from '@/wallet/core/providers/hosted/types/index.js'
+import type { ProviderSpec } from '@/wallet/core/providers/hosted/types/index.js'
 
 import type { LendConfig } from './lend.js'
 
@@ -20,10 +17,11 @@ export interface LendNetworkConfig {
  * @description Configuration object for initializing the Verbs SDK
  */
 export interface VerbsConfig<
-  THostedWalletProviderType extends HostedProviderType,
+  THostedWalletProviderType extends string,
+  TConfigMap extends { [K in THostedWalletProviderType]: unknown },
 > {
   /** Wallet configuration */
-  wallet: WalletConfig<THostedWalletProviderType>
+  wallet: WalletConfig<THostedWalletProviderType, TConfigMap>
   /** Lending provider configuration (optional) */
   lend?: LendConfig
   /** Chains to use for the SDK */
@@ -34,9 +32,12 @@ export interface VerbsConfig<
  * Wallet configuration
  * @description Configuration for wallet providers
  */
-export type WalletConfig<THostedProviderType extends HostedProviderType> = {
+export type WalletConfig<
+  THostedProviderType extends string,
+  TConfigMap extends { [K in THostedProviderType]: unknown },
+> = {
   /** Hosted wallet configuration */
-  hostedWalletConfig: HostedWalletConfig<THostedProviderType>
+  hostedWalletConfig: HostedWalletConfig<THostedProviderType, TConfigMap>
   /** Smart wallet configuration for ERC-4337 infrastructure */
   smartWalletConfig: SmartWalletConfig
 }
@@ -46,10 +47,11 @@ export type WalletConfig<THostedProviderType extends HostedProviderType> = {
  * @description Configuration for hosted wallets / signers
  */
 export interface HostedWalletConfig<
-  THostedProviderType extends HostedProviderType,
+  THostedProviderType extends string,
+  TConfigMap extends { [K in THostedProviderType]: unknown },
 > {
   /** Wallet provider for account creation, management, and signing */
-  provider: ProviderSpec<THostedProviderType>
+  provider: ProviderSpec<THostedProviderType, TConfigMap>
 }
 
 /**

--- a/packages/sdk/src/types/wallet.ts
+++ b/packages/sdk/src/types/wallet.ts
@@ -1,4 +1,3 @@
-import type { Wallet as DynamicWallet } from '@dynamic-labs/wallet-connector-core'
 import type { Address, LocalAccount } from 'viem'
 import type { WebAuthnAccount } from 'viem/account-abstraction'
 
@@ -22,30 +21,4 @@ export type GetSmartWalletOptions = {
   signerOwnerIndex?: number
   walletAddress?: Address
   nonce?: bigint
-}
-
-/**
- * Options for converting a Privy hosted wallet to a Verbs wallet
- * @description Parameters for converting a hosted wallet to a Verbs wallet
- */
-export type PrivyHostedWalletToVerbsWalletOptions = {
-  walletId: string
-  address: string
-}
-
-/**
- * Options for converting a Dynamic hosted wallet to a Verbs wallet
- * @description Parameters for converting a hosted wallet to a Verbs wallet
- */
-export type DynamicHostedWalletToVerbsWalletOptions = {
-  wallet: DynamicWallet
-}
-
-/**
- * Options for converting a Turnkey hosted wallet to a Verbs wallet
- * @description Parameters for converting a hosted wallet to a Verbs wallet
- */
-export type TurnkeyHostedWalletToVerbsWalletOptions = {
-  signWith: string
-  ethereumAddress?: string
 }

--- a/packages/sdk/src/verbs.test.ts
+++ b/packages/sdk/src/verbs.test.ts
@@ -4,21 +4,37 @@ import { describe, expect, it } from 'vitest'
 
 import type { LendMarketConfig, MorphoLendConfig } from '@/types/lend.js'
 import { HostedWalletProviderRegistry } from '@/wallet/core/providers/hosted/registry/HostedWalletProviderRegistry.js'
-import type { PrivyOptions } from '@/wallet/core/providers/hosted/types/index.js'
+import type { HostedWalletProvidersSchema } from '@/wallet/core/providers/hosted/types/index.js'
 import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
+import type {
+  NodeOptionsMap,
+  NodeToVerbsOptionsMap,
+} from '@/wallet/node/providers/hosted/types/index.js'
 
 import { createMockPrivyClient } from './test/MockPrivyClient.js'
 import { externalTest } from './utils/test.js'
 import { Verbs } from './verbs.js'
 
 describe('Verbs SDK', () => {
-  class TestHostedWalletProviderRegistry extends HostedWalletProviderRegistry {
+  type TestInstanceMap = { privy: PrivyHostedWalletProvider }
+  type TestConfigMap = { privy: NodeOptionsMap['privy'] }
+  type TestWalletProvider = HostedWalletProvidersSchema<
+    'privy',
+    TestInstanceMap,
+    TestConfigMap,
+    NodeToVerbsOptionsMap
+  >
+  class TestHostedWalletProviderRegistry extends HostedWalletProviderRegistry<
+    TestInstanceMap,
+    TestConfigMap,
+    'privy'
+  > {
     constructor() {
       super()
       this.register<'privy'>({
         type: 'privy',
-        validateOptions(options): options is PrivyOptions {
-          return Boolean((options as PrivyOptions)?.privyClient)
+        validateOptions(options): options is NodeOptionsMap['privy'] {
+          return Boolean((options as NodeOptionsMap['privy'])?.privyClient)
         },
         create({ chainManager }, options) {
           return new PrivyHostedWalletProvider(
@@ -33,7 +49,11 @@ describe('Verbs SDK', () => {
   describe('Configuration', () => {
     describe('Morpho Provider Configuration', () => {
       it('should create Morpho provider when provider is set to morpho', () => {
-        const verbs = new Verbs(
+        const verbs = new Verbs<
+          TestWalletProvider['providerTypes'],
+          TestWalletProvider,
+          'privy'
+        >(
           {
             chains: [{ chainId: unichain.id }],
             lend: {
@@ -68,7 +88,11 @@ describe('Verbs SDK', () => {
 
       it('should create Morpho provider with custom default slippage', () => {
         const customSlippage = 150
-        const verbs = new Verbs(
+        const verbs = new Verbs<
+          TestWalletProvider['providerTypes'],
+          TestWalletProvider,
+          'privy'
+        >(
           {
             chains: [{ chainId: unichain.id }],
             lend: {
@@ -123,7 +147,11 @@ describe('Verbs SDK', () => {
           lendProvider: 'morpho',
         }
 
-        const verbs = new Verbs(
+        const verbs = new Verbs<
+          TestWalletProvider['providerTypes'],
+          TestWalletProvider,
+          'privy'
+        >(
           {
             chains: [{ chainId: unichain.id }],
             lend: {
@@ -201,7 +229,11 @@ describe('Verbs SDK', () => {
           },
         ]
 
-        const verbs = new Verbs(
+        const verbs = new Verbs<
+          TestWalletProvider['providerTypes'],
+          TestWalletProvider,
+          'privy'
+        >(
           {
             chains: [{ chainId: unichain.id }],
             lend: {
@@ -273,7 +305,11 @@ describe('Verbs SDK', () => {
       })
 
       it('should work without lend configuration', () => {
-        const verbs = new Verbs(
+        const verbs = new Verbs<
+          TestWalletProvider['providerTypes'],
+          TestWalletProvider,
+          'privy'
+        >(
           {
             chains: [{ chainId: unichain.id }],
             wallet: {
@@ -380,7 +416,11 @@ describe('Verbs SDK', () => {
 
     describe('Integration with ChainManager', () => {
       it('should pass chain configuration to lending provider', () => {
-        const verbs = new Verbs(
+        const verbs = new Verbs<
+          TestWalletProvider['providerTypes'],
+          TestWalletProvider,
+          'privy'
+        >(
           {
             chains: [
               { chainId: unichain.id },
@@ -466,7 +506,11 @@ describe('Verbs SDK', () => {
         'should fetch real vault info from Morpho on Unichain',
         async () => {
           // Create Verbs instance with Morpho lending configured
-          const verbs = new Verbs(
+          const verbs = new Verbs<
+            TestWalletProvider['providerTypes'],
+            TestWalletProvider,
+            'privy'
+          >(
             {
               chains: [
                 {
@@ -516,7 +560,11 @@ describe('Verbs SDK', () => {
         'should fetch real vault info from Morpho on Unichain',
         async () => {
           // Create Verbs instance with Morpho lending configured
-          const verbs = new Verbs(
+          const verbs = new Verbs<
+            TestWalletProvider['providerTypes'],
+            TestWalletProvider,
+            'privy'
+          >(
             {
               chains: [
                 {
@@ -603,7 +651,11 @@ describe('Verbs SDK', () => {
       it.runIf(externalTest())(
         'should fetch vault info with enhanced rewards data',
         async () => {
-          const verbs = new Verbs(
+          const verbs = new Verbs<
+            TestWalletProvider['providerTypes'],
+            TestWalletProvider,
+            'privy'
+          >(
             {
               chains: [
                 {
@@ -710,7 +762,11 @@ describe('Verbs SDK', () => {
       )
 
       it.runIf(externalTest())('should get list of vaults', async () => {
-        const verbs = new Verbs(
+        const verbs = new Verbs<
+          TestWalletProvider['providerTypes'],
+          TestWalletProvider,
+          'privy'
+        >(
           {
             chains: [
               {

--- a/packages/sdk/src/verbs.ts
+++ b/packages/sdk/src/verbs.ts
@@ -5,11 +5,9 @@ import { ChainManager } from '@/services/ChainManager.js'
 import type { LendConfig, LendProvider } from '@/types/lend.js'
 import type { VerbsConfig } from '@/types/verbs.js'
 import { WalletNamespace } from '@/wallet/core/namespace/WalletNamespace.js'
+import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { HostedWalletProviderRegistry } from '@/wallet/core/providers/hosted/registry/HostedWalletProviderRegistry.js'
-import type {
-  HostedProviderInstanceMap,
-  HostedProviderType,
-} from '@/wallet/core/providers/hosted/types/index.js'
+import type { HostedWalletProvidersSchema } from '@/wallet/core/providers/hosted/types/index.js'
 import type { SmartWalletProvider } from '@/wallet/core/providers/smart/abstract/SmartWalletProvider.js'
 import { DefaultSmartWalletProvider } from '@/wallet/core/providers/smart/default/DefaultSmartWalletProvider.js'
 import { WalletProvider } from '@/wallet/core/providers/wallet/WalletProvider.js'
@@ -18,21 +16,49 @@ import { WalletProvider } from '@/wallet/core/providers/wallet/WalletProvider.js
  * Main Verbs SDK class
  * @description Core implementation of the Verbs SDK
  */
-export class Verbs<THostedWalletProviderType extends HostedProviderType> {
+export class Verbs<
+  THostedWalletProviderConfigKeys extends string,
+  THostedWalletProvidersSchema extends HostedWalletProvidersSchema<
+    THostedWalletProviderConfigKeys,
+    {
+      [K in THostedWalletProviderConfigKeys]: HostedWalletProvider<
+        K,
+        { [K in THostedWalletProviderConfigKeys]: unknown }
+      >
+    },
+    { [K in THostedWalletProviderConfigKeys]: unknown },
+    { [K in THostedWalletProviderConfigKeys]: unknown }
+  >,
+  THostedWalletProviderType extends THostedWalletProviderConfigKeys,
+> {
   public readonly wallet: WalletNamespace<
-    HostedProviderInstanceMap[THostedWalletProviderType],
+    THostedWalletProviderType,
+    THostedWalletProvidersSchema['providerToVerbsOptions'],
+    THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType],
     SmartWalletProvider
   >
   private chainManager: ChainManager
   private _lend?: VerbsLendNamespace<LendConfig>
   private _lendProvider?: LendProvider<LendConfig>
-  private hostedWalletProvider!: HostedProviderInstanceMap[THostedWalletProviderType]
+  private hostedWalletProvider!: THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType]
   private smartWalletProvider!: SmartWalletProvider
-  private hostedWalletProviderRegistry: HostedWalletProviderRegistry
-
+  private hostedWalletProviderRegistry: HostedWalletProviderRegistry<
+    THostedWalletProvidersSchema['providerInstances'],
+    THostedWalletProvidersSchema['providerConfigs'],
+    THostedWalletProvidersSchema['providerTypes']
+  >
   constructor(
-    config: VerbsConfig<THostedWalletProviderType>,
-    deps: { hostedWalletProviderRegistry: HostedWalletProviderRegistry },
+    config: VerbsConfig<
+      THostedWalletProviderType,
+      THostedWalletProvidersSchema['providerConfigs']
+    >,
+    deps: {
+      hostedWalletProviderRegistry: HostedWalletProviderRegistry<
+        THostedWalletProvidersSchema['providerInstances'],
+        THostedWalletProvidersSchema['providerConfigs'],
+        THostedWalletProvidersSchema['providerTypes']
+      >
+    },
   ) {
     this.chainManager = new ChainManager(config.chains)
     this.hostedWalletProviderRegistry = deps.hostedWalletProviderRegistry
@@ -90,9 +116,14 @@ export class Verbs<THostedWalletProviderType extends HostedProviderType> {
    * @returns WalletProvider instance
    */
   private createWalletProvider(
-    config: VerbsConfig<THostedWalletProviderType>['wallet'],
+    config: VerbsConfig<
+      THostedWalletProviderType,
+      THostedWalletProvidersSchema['providerConfigs']
+    >['wallet'],
   ): WalletProvider<
-    HostedProviderInstanceMap[THostedWalletProviderType],
+    THostedWalletProviderType,
+    THostedWalletProvidersSchema['providerToVerbsOptions'],
+    THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType],
     SmartWalletProvider
   > {
     const hostedWalletProviderConfig = config.hostedWalletConfig.provider
@@ -138,11 +169,16 @@ export class Verbs<THostedWalletProviderType extends HostedProviderType> {
    * @returns WalletNamespace instance
    */
   private createWalletNamespace(
-    config: VerbsConfig<THostedWalletProviderType>['wallet'],
+    config: VerbsConfig<
+      THostedWalletProviderType,
+      THostedWalletProvidersSchema['providerConfigs']
+    >['wallet'],
   ) {
     const walletProvider = this.createWalletProvider(config)
     return new WalletNamespace<
-      HostedProviderInstanceMap[THostedWalletProviderType],
+      THostedWalletProviderType,
+      THostedWalletProvidersSchema['providerToVerbsOptions'],
+      THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType],
       SmartWalletProvider
     >(walletProvider)
   }

--- a/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
+++ b/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
@@ -3,24 +3,28 @@ import type {
   GetSmartWalletOptions,
 } from '@/types/wallet.js'
 import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
-import type { HostedProviderType } from '@/wallet/core/providers/hosted/types/index.js'
 import type { SmartWalletProvider } from '@/wallet/core/providers/smart/abstract/SmartWalletProvider.js'
 import type { WalletProvider } from '@/wallet/core/providers/wallet/WalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWallet.js'
-
 /**
  * Wallet namespace that provides unified wallet operations
  * @description Provides access to wallet functionality through a single provider interface
  */
 export class WalletNamespace<
-  H extends
-    HostedWalletProvider<HostedProviderType> = HostedWalletProvider<HostedProviderType>,
+  THostedProviderType extends string,
+  TToVerbsMap extends Record<THostedProviderType, unknown>,
+  H extends HostedWalletProvider<
+    THostedProviderType,
+    TToVerbsMap
+  > = HostedWalletProvider<THostedProviderType, TToVerbsMap>,
   S extends SmartWalletProvider = SmartWalletProvider,
 > {
-  private provider: WalletProvider<H, S>
+  private provider: WalletProvider<THostedProviderType, TToVerbsMap, H, S>
 
-  constructor(provider: WalletProvider<H, S>) {
+  constructor(
+    provider: WalletProvider<THostedProviderType, TToVerbsMap, H, S>,
+  ) {
     this.provider = provider
   }
 
@@ -70,7 +74,7 @@ export class WalletNamespace<
    * @returns Promise resolving to the Verbs wallet instance
    */
   async hostedWalletToVerbsWallet(
-    params: Parameters<H['toVerbsWallet']>[0],
+    params: TToVerbsMap[THostedProviderType],
   ): Promise<Wallet> {
     return this.provider.hostedWalletToVerbsWallet(params)
   }

--- a/packages/sdk/src/wallet/core/providers/hosted/abstract/HostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/core/providers/hosted/abstract/HostedWalletProvider.ts
@@ -1,8 +1,4 @@
 import type { ChainManager } from '@/services/ChainManager.js'
-import type {
-  HostedProviderType,
-  HostedWalletToVerbsOptionsFor,
-} from '@/wallet/core/providers/hosted/types/index.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 
 /**
@@ -12,7 +8,8 @@ import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
  * as signers for smart wallets or standalone wallet functionality.
  */
 export abstract class HostedWalletProvider<
-  T extends HostedProviderType = HostedProviderType,
+  TType extends string,
+  TOptionsMap extends Record<TType, unknown>,
 > {
   protected chainManager: ChainManager
 
@@ -25,7 +22,5 @@ export abstract class HostedWalletProvider<
    * @param params - Parameters for converting a hosted wallet to a Verbs wallet
    * @returns Promise resolving to the Verbs wallet instance
    */
-  abstract toVerbsWallet(
-    params: HostedWalletToVerbsOptionsFor<T>,
-  ): Promise<Wallet>
+  abstract toVerbsWallet(params: TOptionsMap[TType]): Promise<Wallet>
 }

--- a/packages/sdk/src/wallet/core/providers/hosted/registry/__tests__/HostedWalletProviderRegistry.spec.ts
+++ b/packages/sdk/src/wallet/core/providers/hosted/registry/__tests__/HostedWalletProviderRegistry.spec.ts
@@ -6,16 +6,21 @@ import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { createMockPrivyClient } from '@/test/MockPrivyClient.js'
 import { HostedWalletProviderRegistry } from '@/wallet/core/providers/hosted/registry/HostedWalletProviderRegistry.js'
-import type { PrivyOptions } from '@/wallet/core/providers/hosted/types/index.js'
 import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
+import type { NodeOptionsMap } from '@/wallet/node/providers/hosted/types/index.js'
 
-class TestHostedWalletProviderRegistry extends HostedWalletProviderRegistry {
+type TestInstanceMap = { privy: PrivyHostedWalletProvider }
+class TestHostedWalletProviderRegistry extends HostedWalletProviderRegistry<
+  TestInstanceMap,
+  Pick<NodeOptionsMap, 'privy'>,
+  'privy'
+> {
   constructor() {
     super()
     this.register<'privy'>({
       type: 'privy',
-      validateOptions(options): options is PrivyOptions {
-        return Boolean((options as PrivyOptions)?.privyClient)
+      validateOptions(options): options is NodeOptionsMap['privy'] {
+        return Boolean((options as NodeOptionsMap['privy'])?.privyClient)
       },
       create({ chainManager }, options) {
         return new PrivyHostedWalletProvider(options.privyClient, chainManager)

--- a/packages/sdk/src/wallet/core/providers/hosted/types/index.ts
+++ b/packages/sdk/src/wallet/core/providers/hosted/types/index.ts
@@ -1,79 +1,73 @@
-import type { PrivyClient } from '@privy-io/server-auth'
-import type { TurnkeySDKClientBase } from '@turnkey/core'
-import type { TurnkeyClient as TurnkeyHttpClient } from '@turnkey/http'
-import type { TurnkeyServerClient } from '@turnkey/sdk-server'
-
 import type { ChainManager } from '@/services/ChainManager.js'
-import type {
-  DynamicHostedWalletToVerbsWalletOptions,
-  PrivyHostedWalletToVerbsWalletOptions,
-  TurnkeyHostedWalletToVerbsWalletOptions,
-} from '@/types/wallet.js'
-import type { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
-import type { TurnkeyHostedWalletProvider } from '@/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
-import type { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
+import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 
-export interface PrivyOptions {
-  privyClient: PrivyClient
-}
-
-export interface TurnkeyOptions {
-  /**
-   * Turnkey client instance (HTTP, server, or core SDK base)
-   */
-  client: TurnkeyHttpClient | TurnkeyServerClient | TurnkeySDKClientBase
-  /**
-   * Turnkey organization ID that owns the signing key
-   */
-  organizationId: string
-}
-
-export type DynamicOptions = undefined
-export interface HostedProviderConfigMap {
-  privy: PrivyOptions
-  dynamic: DynamicOptions
-  turnkey: TurnkeyOptions
-}
-
-export interface HostedProviderInstanceMap {
-  privy: PrivyHostedWalletProvider
-  dynamic: DynamicHostedWalletProvider
-  turnkey: TurnkeyHostedWalletProvider
-}
-
-export interface HostedWalletToVerbsOptionsMap {
-  privy: PrivyHostedWalletToVerbsWalletOptions
-  dynamic: DynamicHostedWalletToVerbsWalletOptions
-  turnkey: TurnkeyHostedWalletToVerbsWalletOptions
-}
-
-export type HostedProviderType = keyof HostedProviderConfigMap
-
-export type NodeHostedProviderType = Extract<
-  HostedProviderType,
-  'privy' | 'turnkey'
->
-
-export type HostedWalletToVerbsType = keyof HostedWalletToVerbsOptionsMap
-
+/**
+ * Common dependencies provided to hosted provider factories
+ * @description
+ * Environment-agnostic services that providers require at creation time.
+ * Currently limited to `ChainManager`, but can be extended as needed.
+ */
 export interface HostedProviderDeps {
   chainManager: ChainManager
 }
 
-export type ProviderSpec<TType extends HostedProviderType> = {
+/**
+ * Provider registration specification
+ * @description
+ * Declarative description of a hosted wallet provider used when registering
+ * a provider factory in a registry.
+ * @template TType Unique provider key (e.g. 'privy', 'turnkey')
+ * @template TConfig Configuration object type for the provider
+ */
+export type ProviderSpec<
+  TType extends string,
+  TConfigMap extends { [K in TType]: unknown },
+> = {
   type: TType
-  config?: HostedProviderConfigMap[TType]
+  config?: TConfigMap[TType]
 }
 
-export interface HostedProviderFactory<TType extends HostedProviderType> {
+/**
+ * Hosted wallet provider factory
+ * @description
+ * Factory contract used by registries to validate configuration and create
+ * concrete hosted wallet provider instances.
+ * @template TType Unique provider key
+ * @template TInstance Concrete provider instance produced by this factory
+ * @template TOptions Options type accepted by `validateOptions` and `create`
+ */
+export interface HostedProviderFactory<
+  TType extends string,
+  TInstance,
+  TOptions = unknown,
+> {
   type: TType
-  validateOptions(options: unknown): options is HostedProviderConfigMap[TType]
-  create(
-    deps: HostedProviderDeps,
-    options: HostedProviderConfigMap[TType],
-  ): HostedProviderInstanceMap[TType]
+  validateOptions(options: unknown): options is TOptions
+  create(deps: HostedProviderDeps, options: TOptions): TInstance
 }
 
-// Helper to get options type for a given provider type
-export type HostedWalletToVerbsOptionsFor<T extends HostedProviderType> =
-  HostedWalletToVerbsOptionsMap[T]
+/**
+ * Complete hosted wallet providers schema (environment-agnostic)
+ * @description
+ * Bundles provider type keys, concrete provider instances, creation configs,
+ * and `toVerbsWallet` parameter types for a given environment (Node or React).
+ * This schema enables precise typing in `Verbs` and registries without widening
+ * keys to generic `string`.
+ * @template ProviderTypes Union of provider keys for the environment
+ * @template ProviderInstanceMap Map of provider key to concrete instance
+ * @template ProviderConfigMap Map of provider key to factory config type
+ * @template ToVerbsOptionsMap Map of provider key to `toVerbsWallet` params
+ */
+export type HostedWalletProvidersSchema<
+  ProviderTypes extends string,
+  ProviderInstanceMap extends {
+    [K in ProviderTypes]: HostedWalletProvider<K, ToVerbsOptionsMap>
+  },
+  ProviderConfigMap extends { [K in ProviderTypes]: unknown },
+  ToVerbsOptionsMap extends { [K in ProviderTypes]: unknown },
+> = {
+  providerTypes: ProviderTypes
+  providerInstances: ProviderInstanceMap
+  providerConfigs: ProviderConfigMap
+  providerToVerbsOptions: ToVerbsOptionsMap
+}

--- a/packages/sdk/src/wallet/core/providers/wallet/WalletProvider.ts
+++ b/packages/sdk/src/wallet/core/providers/wallet/WalletProvider.ts
@@ -5,7 +5,6 @@ import type {
   GetSmartWalletOptions,
 } from '@/types/wallet.js'
 import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
-import type { HostedProviderType } from '@/wallet/core/providers/hosted/types/index.js'
 import type { SmartWalletProvider } from '@/wallet/core/providers/smart/abstract/SmartWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWallet.js'
@@ -16,7 +15,9 @@ import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWall
  * Provides a unified interface for all wallet operations while supporting pluggable providers.
  */
 export class WalletProvider<
-  H extends HostedWalletProvider<HostedProviderType>,
+  THostedProviderType extends string,
+  TToVerbsMap extends Record<THostedProviderType, unknown>,
+  H extends HostedWalletProvider<THostedProviderType, TToVerbsMap>,
   S extends SmartWalletProvider = SmartWalletProvider,
 > {
   constructor(
@@ -58,7 +59,7 @@ export class WalletProvider<
   }
 
   async hostedWalletToVerbsWallet(
-    params: Parameters<H['toVerbsWallet']>[0],
+    params: TToVerbsMap[THostedProviderType],
   ): Promise<Wallet> {
     return this.hostedWalletProvider.toVerbsWallet(params)
   }

--- a/packages/sdk/src/wallet/node/index.ts
+++ b/packages/sdk/src/wallet/node/index.ts
@@ -1,2 +1,7 @@
 export { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
+export type {
+  NodeHostedWalletProvidersSchema,
+  NodeOptionsMap,
+  NodeProviderTypes,
+} from '@/wallet/node/providers/hosted/types/index.js'
 export { PrivyWallet } from '@/wallet/node/wallets/hosted/privy/PrivyWallet.js'

--- a/packages/sdk/src/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.ts
@@ -2,16 +2,22 @@ import type { PrivyClient } from '@privy-io/server-auth'
 import { getAddress } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
-import type { PrivyHostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import type {
+  NodeToVerbsOptionsMap,
+  PrivyHostedWalletToVerbsWalletOptions,
+} from '@/wallet/node/providers/hosted/types/index.js'
 import { PrivyWallet } from '@/wallet/node/wallets/hosted/privy/PrivyWallet.js'
 
 /**
  * Privy wallet provider implementation
  * @description Wallet provider implementation using Privy service
  */
-export class PrivyHostedWalletProvider extends HostedWalletProvider<'privy'> {
+export class PrivyHostedWalletProvider extends HostedWalletProvider<
+  'privy',
+  NodeToVerbsOptionsMap
+> {
   /**
    * Create a new Privy wallet provider
    * @param privyClient - Privy client instance

--- a/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
@@ -1,22 +1,23 @@
 import { HostedWalletProviderRegistry } from '@/wallet/core/providers/hosted/registry/HostedWalletProviderRegistry.js'
-import type {
-  PrivyOptions,
-  TurnkeyOptions,
-} from '@/wallet/core/providers/hosted/types/index.js'
 import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
 import { TurnkeyHostedWalletProvider } from '@/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
+import type {
+  NodeHostedProviderInstanceMap,
+  NodeOptionsMap,
+  NodeProviderTypes,
+} from '@/wallet/node/providers/hosted/types/index.js'
 
-/**
- * Node environment hosted wallet registry.
- * Registers server-safe providers for use in Node.
- */
-export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegistry {
+export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegistry<
+  NodeHostedProviderInstanceMap,
+  NodeOptionsMap,
+  NodeProviderTypes
+> {
   public constructor() {
     super()
     this.register<'privy'>({
       type: 'privy',
-      validateOptions(options): options is PrivyOptions {
-        return Boolean((options as PrivyOptions)?.privyClient)
+      validateOptions(options): options is NodeOptionsMap['privy'] {
+        return Boolean((options as NodeOptionsMap['privy'])?.privyClient)
       },
       create({ chainManager }, options) {
         return new PrivyHostedWalletProvider(options.privyClient, chainManager)
@@ -25,8 +26,8 @@ export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegist
 
     this.register<'turnkey'>({
       type: 'turnkey',
-      validateOptions(options): options is TurnkeyOptions {
-        const o = options as TurnkeyOptions
+      validateOptions(options): options is NodeOptionsMap['turnkey'] {
+        const o = options as NodeOptionsMap['turnkey']
         return Boolean(o?.client) && typeof o?.organizationId === 'string'
       },
       create({ chainManager }, options) {

--- a/packages/sdk/src/wallet/node/providers/hosted/registry/__tests__/NodeHostedWalletProviderRegistry.spec.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/registry/__tests__/NodeHostedWalletProviderRegistry.spec.ts
@@ -6,10 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { createMockPrivyClient } from '@/test/MockPrivyClient.js'
-import type { PrivyOptions } from '@/wallet/core/providers/hosted/types/index.js'
 import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
 import { NodeHostedWalletProviderRegistry } from '@/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.js'
 import { TurnkeyHostedWalletProvider } from '@/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
+import type { NodeOptionsMap } from '@/wallet/node/providers/hosted/types/index.js'
 
 describe('NodeHostedWalletProviderRegistry', () => {
   const mockChainManager = new MockChainManager({
@@ -31,9 +31,11 @@ describe('NodeHostedWalletProviderRegistry', () => {
     const factory = registry.getFactory('privy')
 
     expect(factory.type).toBe('privy')
-    expect(factory.validateOptions?.({ privyClient: mockPrivyClient })).toBe(
-      true,
-    )
+    expect(
+      factory.validateOptions?.({
+        privyClient: mockPrivyClient,
+      } as NodeOptionsMap['privy']),
+    ).toBe(true)
     // Invalid shape should not pass validation
     expect(factory.validateOptions?.({})).toBe(false)
   })
@@ -44,7 +46,7 @@ describe('NodeHostedWalletProviderRegistry', () => {
 
     const provider = factory.create({ chainManager: mockChainManager }, {
       privyClient: mockPrivyClient,
-    } satisfies PrivyOptions)
+    } as NodeOptionsMap['privy'])
 
     expect(provider).toBeInstanceOf(PrivyHostedWalletProvider)
   })
@@ -58,7 +60,7 @@ describe('NodeHostedWalletProviderRegistry', () => {
       factory.validateOptions?.({
         client: mockTurnkeyClient,
         organizationId: 'org_123',
-      }),
+      } as NodeOptionsMap['turnkey']),
     ).toBe(true)
     // Invalid shape should not pass validation
     expect(factory.validateOptions?.({})).toBe(false)

--- a/packages/sdk/src/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
@@ -3,9 +3,9 @@ import type { TurnkeyClient as TurnkeyHttpClient } from '@turnkey/http'
 import type { TurnkeyServerClient } from '@turnkey/sdk-server'
 
 import type { ChainManager } from '@/services/ChainManager.js'
-import type { TurnkeyHostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import type { NodeToVerbsOptionsMap } from '@/wallet/node/providers/hosted/types/index.js'
 import { TurnkeyWallet } from '@/wallet/node/wallets/hosted/turnkey/TurnkeyWallet.js'
 
 /**
@@ -15,7 +15,10 @@ import { TurnkeyWallet } from '@/wallet/node/wallets/hosted/turnkey/TurnkeyWalle
  * environments where the Turnkey client (HTTP, server, or core SDK) and
  * organization context are provided at construction time.
  */
-export class TurnkeyHostedWalletProvider extends HostedWalletProvider<'turnkey'> {
+export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
+  'turnkey',
+  NodeToVerbsOptionsMap
+> {
   /**
    * Create a new Turnkey wallet provider
    * @param client - Turnkey client instance (HTTP, server, or core SDK base)
@@ -43,7 +46,7 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<'turnkey'>
    * @returns Promise resolving to a Verbs-compatible wallet instance
    */
   async toVerbsWallet(
-    params: TurnkeyHostedWalletToVerbsWalletOptions,
+    params: NodeToVerbsOptionsMap['turnkey'],
   ): Promise<Wallet> {
     return TurnkeyWallet.create({
       client: this.client,

--- a/packages/sdk/src/wallet/node/providers/hosted/types/index.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/types/index.ts
@@ -1,0 +1,101 @@
+import type { PrivyClient } from '@privy-io/server-auth'
+import type { TurnkeySDKClientBase } from '@turnkey/core'
+import type { TurnkeyClient as TurnkeyHttpClient } from '@turnkey/http'
+import type { TurnkeyServerClient } from '@turnkey/sdk-server'
+
+import type { HostedWalletProvidersSchema } from '@/wallet/core/providers/hosted/types/index.js'
+import type { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
+import type { TurnkeyHostedWalletProvider } from '@/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
+
+/**
+ * Node provider type keys
+ * @description
+ * Narrow union of provider identifiers supported in the Node environment.
+ * Uses an intersection of the keys from each map to guarantee that all maps
+ * stay in sync (options, instances, and toVerbs options) at compile time.
+ */
+export type NodeProviderTypes = keyof NodeOptionsMap &
+  keyof NodeHostedProviderInstanceMap &
+  keyof NodeToVerbsOptionsMap
+
+/**
+ * Configuration options per Node hosted wallet provider
+ * @description
+ * Strongly-typed configuration inputs passed to each provider factory when
+ * creating a hosted wallet provider for Node.
+ */
+export interface NodeOptionsMap {
+  /**
+   * Privy provider configuration
+   * @property privyClient Server-side Privy client instance used to query/create wallets
+   */
+  privy: { privyClient: PrivyClient }
+  /**
+   * Turnkey provider configuration
+   * @property client Turnkey SDK/HTTP client used to sign and manage keys
+   * @property organizationId Turnkey organization identifier that owns the key material
+   */
+  turnkey: {
+    client: TurnkeyHttpClient | TurnkeyServerClient | TurnkeySDKClientBase
+    organizationId: string
+  }
+}
+
+/**
+ * Options for converting a Turnkey hosted wallet to a Verbs wallet
+ * @description Parameters for converting a hosted wallet to a Verbs wallet
+ * @property signWith This can be a wallet account address, private key address, or private key ID.
+ * @property ethereumAddress Ethereum address to use for this account, in the case that a private key ID is used to sign.
+ * If left undefined, `createAccount` will fetch it from the Turnkey API. We recommend setting this if you're using a passkey
+ * client, so that your users are not prompted for a passkey signature just to fetch their address. You may leave this
+ * undefined if using an API key client.
+ */
+export type TurnkeyHostedWalletToVerbsWalletOptions = {
+  signWith: string
+  ethereumAddress?: string
+}
+
+/**
+ * Options for converting a Privy hosted wallet to a Verbs wallet
+ * @description Parameters for converting a hosted wallet to a Verbs wallet
+ * @property walletId Privy wallet identifier
+ * @property address Ethereum address of the wallet
+ */
+export type PrivyHostedWalletToVerbsWalletOptions = {
+  walletId: string
+  address: string
+}
+
+/**
+ * Node environment hosted wallet registry.
+ * Registers server-safe providers for use in Node.
+ */
+export type NodeHostedProviderInstanceMap = {
+  privy: PrivyHostedWalletProvider
+  turnkey: TurnkeyHostedWalletProvider
+}
+
+/**
+ * Parameters required to convert each hosted wallet to a Verbs wallet (Node)
+ * @description
+ * Provider-specific, caller-supplied data needed by `toVerbsWallet`.
+ */
+export type NodeToVerbsOptionsMap = {
+  privy: PrivyHostedWalletToVerbsWalletOptions
+  turnkey: TurnkeyHostedWalletToVerbsWalletOptions
+}
+
+/**
+ * Complete Node hosted wallet providers schema
+ * @description
+ * Bundles provider type keys, concrete provider instances, creation configs,
+ * and `toVerbsWallet` parameter types for the Node environment.
+ * This schema is used to type `Verbs` and its registries without widening
+ * to generic `string` keys.
+ */
+export type NodeHostedWalletProvidersSchema = HostedWalletProvidersSchema<
+  NodeProviderTypes,
+  NodeHostedProviderInstanceMap,
+  NodeOptionsMap,
+  NodeToVerbsOptionsMap
+>

--- a/packages/sdk/src/wallet/react/index.ts
+++ b/packages/sdk/src/wallet/react/index.ts
@@ -1,1 +1,5 @@
+export type {
+  ReactHostedWalletProvidersSchema,
+  ReactProviderTypes,
+} from '@/wallet/react/providers/hosted/types/index.js'
 export { DynamicWallet } from '@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js'

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.ts
@@ -1,14 +1,20 @@
 import type { ChainManager } from '@/services/ChainManager.js'
-import type { DynamicHostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import type {
+  DynamicHostedWalletToVerbsWalletOptions,
+  ReactToVerbsOptionsMap,
+} from '@/wallet/react/providers/hosted/types/index.js'
 import { DynamicWallet } from '@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js'
 
 /**
  * Dynamic wallet provider implementation
  * @description Wallet provider implementation using Dynamic service
  */
-export class DynamicHostedWalletProvider extends HostedWalletProvider<'dynamic'> {
+export class DynamicHostedWalletProvider extends HostedWalletProvider<
+  'dynamic',
+  ReactToVerbsOptionsMap
+> {
   /**
    * Create a new Dynamic wallet provider
    */

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/__mocks__/DynamicHostedWalletProviderMock.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/__mocks__/DynamicHostedWalletProviderMock.ts
@@ -3,15 +3,21 @@ import { vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
-import type { DynamicHostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import type {
+  DynamicHostedWalletToVerbsWalletOptions,
+  ReactToVerbsOptionsMap,
+} from '@/wallet/react/providers/hosted/types/index.js'
 
 /**
  * Minimal mock implementation matching the shape of HostedWalletProvider<'dynamic'>
  * for use in unit tests without importing browser-only dependencies.
  */
-export class DynamicHostedWalletProviderMock extends HostedWalletProvider<'dynamic'> {
+export class DynamicHostedWalletProviderMock extends HostedWalletProvider<
+  'dynamic',
+  ReactToVerbsOptionsMap
+> {
   // Exposed mock for assertions if needed
   public readonly toVerbsWalletMock = vi.fn(
     async (

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/__tests__/DynamicHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/__tests__/DynamicHostedWalletProvider.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
-import type { DynamicHostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
 import { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
+import type { DynamicHostedWalletToVerbsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
 
 // Mock DynamicWallet module to avoid importing browser-related deps
 vi.mock('@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js', () => {

--- a/packages/sdk/src/wallet/react/providers/hosted/types/index.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/types/index.ts
@@ -1,0 +1,65 @@
+import type { Wallet as DynamicWallet } from '@dynamic-labs/wallet-connector-core'
+
+import type { HostedWalletProvidersSchema } from '@/wallet/core/providers/hosted/types/index.js'
+import type { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
+
+/**
+ * React provider type keys
+ * @description
+ * Narrow union of provider identifiers supported in the React/browser environment.
+ * Uses an intersection of the keys from each map to help keep maps in sync
+ * at compile time.
+ */
+export type ReactProviderTypes = keyof ReactOptionsMap &
+  keyof ReactHostedProviderInstanceMap
+
+/**
+ * Configuration options per React hosted wallet provider
+ * @description
+ * Strongly-typed configuration inputs passed to each provider factory when
+ * creating a hosted wallet provider for React. The Dynamic provider has no
+ * build-time options.
+ */
+export interface ReactOptionsMap {
+  dynamic: undefined
+}
+
+/**
+ * Options for converting a Dynamic hosted wallet to a Verbs wallet
+ * @description Parameters for converting a hosted wallet to a Verbs wallet
+ * @property wallet Dynamic wallet instance obtained from the Dynamic connector
+ */
+export type DynamicHostedWalletToVerbsWalletOptions = {
+  wallet: DynamicWallet
+}
+
+/**
+ * React/browser hosted wallet registry
+ * @description Registers browser-only providers for client apps.
+ */
+export type ReactHostedProviderInstanceMap = {
+  dynamic: DynamicHostedWalletProvider
+}
+
+/**
+ * Parameters required to convert each hosted wallet to a Verbs wallet (React)
+ * @description Provider-specific, caller-supplied data needed by `toVerbsWallet`.
+ */
+export type ReactToVerbsOptionsMap = {
+  dynamic: DynamicHostedWalletToVerbsWalletOptions
+}
+
+/**
+ * Complete React hosted wallet providers schema
+ * @description
+ * Bundles provider type keys, concrete provider instances, creation configs,
+ * and `toVerbsWallet` parameter types for the React environment.
+ * This schema is used to type `Verbs` and its registries without widening
+ * to generic `string` keys.
+ */
+export type ReactHostedWalletProvidersSchema = HostedWalletProvidersSchema<
+  ReactProviderTypes,
+  ReactHostedProviderInstanceMap,
+  ReactOptionsMap,
+  ReactToVerbsOptionsMap
+>

--- a/packages/sdk/src/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.ts
@@ -1,17 +1,21 @@
 import { HostedWalletProviderRegistry } from '@/wallet/core/providers/hosted/registry/HostedWalletProviderRegistry.js'
-import type { DynamicOptions } from '@/wallet/core/providers/hosted/types/index.js'
 import { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
+import type {
+  ReactHostedProviderInstanceMap,
+  ReactOptionsMap,
+  ReactProviderTypes,
+} from '@/wallet/react/providers/hosted/types/index.js'
 
-/**
- * React/browser hosted wallet registry.
- * Registers browser-only providers for client apps.
- */
-export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegistry {
+export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegistry<
+  ReactHostedProviderInstanceMap,
+  ReactOptionsMap,
+  ReactProviderTypes
+> {
   public constructor() {
     super()
     this.register<'dynamic'>({
       type: 'dynamic',
-      validateOptions(_options): _options is DynamicOptions {
+      validateOptions(_options): _options is ReactOptionsMap['dynamic'] {
         return true
       },
       create({ chainManager }, _options) {

--- a/packages/sdk/src/wallet/react/providers/registry/__tests__/ReactHostedWalletProviderRegistry.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/registry/__tests__/ReactHostedWalletProviderRegistry.spec.ts
@@ -3,8 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
-import type { DynamicOptions } from '@/wallet/core/providers/hosted/types/index.js'
 import { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
+import type { ReactOptionsMap } from '@/wallet/react/providers/hosted/types/index.js'
 import { ReactHostedWalletProviderRegistry } from '@/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.js'
 
 // Mock the dynamic provider to avoid importing any browser-only dependencies
@@ -33,9 +33,9 @@ describe('ReactHostedWalletProviderRegistry', () => {
 
     expect(factory.type).toBe('dynamic')
     // Dynamic options are currently empty; any object should validate to true
-    expect(factory.validateOptions?.(undefined satisfies DynamicOptions)).toBe(
-      true,
-    )
+    expect(
+      factory.validateOptions?.(undefined as ReactOptionsMap['dynamic']),
+    ).toBe(true)
   })
 
   it('creates a DynamicHostedWalletProvider instance', () => {
@@ -44,7 +44,7 @@ describe('ReactHostedWalletProviderRegistry', () => {
 
     const provider = factory.create(
       { chainManager: mockChainManager },
-      undefined as DynamicOptions,
+      undefined as ReactOptionsMap['dynamic'],
     )
 
     expect(provider).toBeInstanceOf(DynamicHostedWalletProvider)

--- a/packages/sdk/src/wallet/react/wallets/hosted/dynamic/DynamicWallet.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/dynamic/DynamicWallet.ts
@@ -12,8 +12,8 @@ import { toAccount } from 'viem/accounts'
 
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
-import type { DynamicHostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
 import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import type { DynamicHostedWalletToVerbsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
 
 /**
  * Dynamic wallet implementation

--- a/packages/sdk/src/wallet/react/wallets/hosted/dynamic/__tests__/DynamicWallet.spec.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/dynamic/__tests__/DynamicWallet.spec.ts
@@ -14,7 +14,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { getRandomAddress } from '@/test/utils.js'
-import type { DynamicHostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
+import type { DynamicHostedWalletToVerbsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
 import { DynamicWallet } from '@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js'
 
 vi.mock('viem', async () => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,7 +246,7 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       '@privy-io/server-auth':
-        specifier: '>=1.28.0'
+        specifier: '>=1.31.1'
         version: 1.31.1(bufferutil@4.0.9)(encoding@0.1.13)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))
       '@turnkey/core':
         specifier: '>=1.1.1'
@@ -8856,7 +8856,7 @@ snapshots:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
       '@mysten/bcs': 1.5.0
-      '@noble/curves': 1.9.6
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@scure/bip32': 1.7.0
@@ -9118,7 +9118,7 @@ snapshots:
       '@privy-io/api-base': 1.6.0
       bs58: 5.0.0
       libphonenumber-js: 1.12.10
-      viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.37.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -10140,7 +10140,7 @@ snapshots:
   '@solana/web3.js@1.98.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.27.6
-      '@noble/curves': 1.9.6
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
       '@solana/codecs-numbers': 2.3.0(typescript@5.8.3)
@@ -11720,11 +11720,6 @@ snapshots:
   '@zkochan/js-yaml@0.0.7':
     dependencies:
       argparse: 2.0.1
-
-  abitype@1.0.8(typescript@5.8.3)(zod@3.25.76):
-    optionalDependencies:
-      typescript: 5.8.3
-      zod: 3.25.76
 
   abitype@1.0.8(typescript@5.8.3)(zod@4.0.5):
     optionalDependencies:
@@ -14065,7 +14060,7 @@ snapshots:
   ox@0.6.7(typescript@5.8.3)(zod@4.0.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.9.6
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
@@ -14094,26 +14089,11 @@ snapshots:
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.6
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.1.0(typescript@5.8.3)(zod@4.0.5)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.8.1(typescript@5.8.3)(zod@3.25.76):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.0
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.4
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.8.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.3
@@ -15532,23 +15512,6 @@ snapshots:
       abitype: 1.0.8(typescript@5.8.3)(zod@4.0.5)
       isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.7.1(typescript@5.8.3)(zod@4.0.5)
-      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.9.2
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.8.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.8.1(typescript@5.8.3)(zod@3.25.76)
       ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.8.3


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/verbs/issues/146

### Summary

This PR moves all Node- and React-specific wallet types out of core and into their corresponding environment-scoped folders, making `core` completely environment-agnostic. This prevents accidental coupling to browser or Node dependencies in the wrong runtime, and positions us to publish separate Node/React packages in the future.

### Why
-   Keep core runtime-agnostic to avoid accidental imports of Node/browser-only deps in the wrong environment.
-   Enable future split publishing targets (Node vs React).
-   Maintain per-provider instance specificity with stronger typing.