### PR TITLE
feat(smart-wallet): `removeSigner` method

### DIFF
--- a/packages/sdk/src/wallet/core/wallets/smart/abstract/SmartWallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/abstract/SmartWallet.ts
@@ -16,8 +16,6 @@ export abstract class SmartWallet extends Wallet {
     throw new Error('walletClient is not supported on SmartWallet')
   }
 
-  // TODO: add removeSigner method
-
   /**
    * Send a transaction using this smart wallet
    * @description Executes a transaction through the smart wallet, handling gas sponsorship
@@ -53,6 +51,20 @@ export abstract class SmartWallet extends Wallet {
    * @throws Error if the add operation fails or the owner index cannot be found
    */
   abstract addSigner(signer: Signer, chainId: SupportedChainId): Promise<number>
+
+  /**
+   * Remove a signer from the smart wallet
+   * @param signer - Ethereum address (EOA) or a `WebAuthnAccount` to remove
+   * @param chainId - Target chain on which the smart wallet operates
+   * @param signerIndex - Index of the signer to remove, if not provided, it will be found by
+   * doing a lookup on the smart wallet contract.
+   * @returns Promise resolving to the receipt of the remove operation
+   */
+  abstract removeSigner(
+    signer: Signer,
+    chainId: SupportedChainId,
+    signerIndex?: number,
+  ): Promise<WaitForUserOperationReceiptReturnType>
 
   /**
    * Find the index of a signer in the smart wallet

--- a/packages/sdk/src/wallet/core/wallets/smart/abstract/__mocks__/SmartWallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/abstract/__mocks__/SmartWallet.ts
@@ -22,6 +22,12 @@ export type CreateSmartWalletMockOptions = {
     signer: Address | { type: 'webAuthn'; publicKey: Hex },
     chainId: SupportedChainId,
   ) => Promise<number>
+  /** Custom implementation for removeSigner */
+  removeSignerImpl?: (
+    signer: Address | { type: 'webAuthn'; publicKey: Hex },
+    chainId: SupportedChainId,
+    signerIndex?: number,
+  ) => Promise<WaitForUserOperationReceiptReturnType>
   /** Custom implementation for send */
   sendImpl?: (
     transactionData: TransactionData,
@@ -82,6 +88,18 @@ export function createMock(
     },
   )
 
+  const removeSigner = vi.fn(
+    async (
+      signer: Address | { type: 'webAuthn'; publicKey: Hex },
+      chainId: SupportedChainId,
+      signerIndex?: number,
+    ): Promise<WaitForUserOperationReceiptReturnType> => {
+      if (options.removeSignerImpl)
+        return options.removeSignerImpl(signer, chainId, signerIndex)
+      return defaultReceipt
+    },
+  )
+
   const send = vi.fn(
     async (
       transactionData: TransactionData,
@@ -132,6 +150,7 @@ export function createMock(
     },
     addSigner,
     findSignerIndex,
+    removeSigner,
     walletClient,
     send,
     sendBatch,


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/verbs/issues/79

Adds the `removeSigner` method to the `SmartWallet` base class. This provides the ability for the Actions SDK to remove a signer from a `SmartWallet` instance