### PR TITLE
feat: add `createSigner` to wallet namespace

### DIFF
--- a/packages/demo/backend/src/app.integration.spec.ts
+++ b/packages/demo/backend/src/app.integration.spec.ts
@@ -68,6 +68,16 @@ vi.mock('./config/verbs.js', () => ({
           }
         },
       ),
+      createSigner: vi.fn(
+        async ({ address }: { walletId: string; address: string }) => {
+          return {
+            address: address,
+            signer: {
+              address: address,
+            },
+          }
+        },
+      ),
       getSmartWallet: vi.fn(
         async ({ signer }: { signer: { address: string } }) => {
           return {

--- a/packages/demo/backend/src/services/wallet.spec.ts
+++ b/packages/demo/backend/src/services/wallet.spec.ts
@@ -20,6 +20,10 @@ const mockVerbs = {
         address,
       },
     })),
+    createSigner: vi.fn(({ address }: { address: string }) => ({
+      address,
+      type: 'local',
+    })),
   },
 }
 const mockPrivyClient = {
@@ -65,6 +69,7 @@ describe('Wallet Service', () => {
       expect(mockVerbs.wallet.createSmartWallet).toHaveBeenCalledWith({
         owners: ['0x1234567890123456789012345678901234567890'],
         signer: {
+          type: 'local',
           address: '0x1234567890123456789012345678901234567890',
         },
       })
@@ -105,6 +110,7 @@ describe('Wallet Service', () => {
 
       expect(mockVerbs.wallet.getSmartWallet).toHaveBeenCalledWith({
         signer: {
+          type: 'local',
           address: '0x1234567890123456789012345678901234567890',
         },
         deploymentOwners: ['0x1234567890123456789012345678901234567890'],
@@ -263,6 +269,7 @@ describe('Wallet Service', () => {
       expect(mockVerbs.wallet.getSmartWallet).toHaveBeenCalledWith({
         signer: {
           address: '0x1234567890123456789012345678901234567890',
+          type: 'local',
         },
         deploymentOwners: ['0x1234567890123456789012345678901234567890'],
       })
@@ -308,6 +315,7 @@ describe('Wallet Service', () => {
       expect(mockVerbs.wallet.getSmartWallet).toHaveBeenCalledWith({
         signer: {
           address: mockWallet.address,
+          type: 'local',
         },
         deploymentOwners: [mockWallet.address],
       })

--- a/packages/demo/backend/src/services/wallet.ts
+++ b/packages/demo/backend/src/services/wallet.ts
@@ -36,13 +36,13 @@ export async function createWallet(): Promise<{
   const privyWallet = await privyClient.walletApi.createWallet({
     chainType: 'ethereum',
   })
-  const verbsPrivyWallet = await verbs.wallet.hostedWalletToVerbsWallet({
+  const privySigner = await verbs.wallet.createSigner({
     walletId: privyWallet.id,
-    address: privyWallet.address,
+    address: getAddress(privyWallet.address),
   })
   const wallet = await verbs.wallet.createSmartWallet({
-    owners: [verbsPrivyWallet.address],
-    signer: verbsPrivyWallet.signer,
+    owners: [privySigner.address],
+    signer: privySigner,
   })
   const smartWalletAddress = wallet.address
   return {
@@ -79,12 +79,12 @@ export async function getWallet(
     return null
   }
 
-  const verbsPrivyWallet = await verbs.wallet.hostedWalletToVerbsWallet({
+  const privySigner = await verbs.wallet.createSigner({
     walletId: privyWallet.id!,
-    address: privyWallet.address,
+    address: getAddress(privyWallet.address),
   })
   const wallet = await verbs.wallet.getSmartWallet({
-    signer: verbsPrivyWallet.signer,
+    signer: privySigner,
     deploymentOwners: [getAddress(privyWallet.address)],
   })
 
@@ -104,13 +104,13 @@ export async function getAllWallets(
     const response = await privyClient.walletApi.getWallets(options)
     return Promise.all(
       response.data.map(async (privyWallet) => {
-        const verbsPrivyWallet = await verbs.wallet.hostedWalletToVerbsWallet({
+        const privySigner = await verbs.wallet.createSigner({
           walletId: privyWallet.id,
-          address: privyWallet.address,
+          address: getAddress(privyWallet.address),
         })
         const wallet = await verbs.wallet.getSmartWallet({
-          signer: verbsPrivyWallet.signer,
-          deploymentOwners: [getAddress(privyWallet.address)],
+          signer: privySigner,
+          deploymentOwners: [privySigner.address],
         })
         return {
           wallet,

--- a/packages/sdk/src/verbs.ts
+++ b/packages/sdk/src/verbs.ts
@@ -10,7 +10,7 @@ import type { HostedWalletProviderRegistry } from '@/wallet/core/providers/hoste
 import type { HostedWalletProvidersSchema } from '@/wallet/core/providers/hosted/types/index.js'
 import type { SmartWalletProvider } from '@/wallet/core/providers/smart/abstract/SmartWalletProvider.js'
 import { DefaultSmartWalletProvider } from '@/wallet/core/providers/smart/default/DefaultSmartWalletProvider.js'
-import { WalletProvider } from '@/wallet/core/providers/wallet/WalletProvider.js'
+import { WalletProvider } from '@/wallet/core/providers/WalletProvider.js'
 
 /**
  * Main Verbs SDK class

--- a/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
+++ b/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
@@ -1,10 +1,12 @@
+import type { LocalAccount } from 'viem'
+
 import type {
   CreateSmartWalletOptions,
   GetSmartWalletOptions,
 } from '@/types/wallet.js'
 import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { SmartWalletProvider } from '@/wallet/core/providers/smart/abstract/SmartWalletProvider.js'
-import type { WalletProvider } from '@/wallet/core/providers/wallet/WalletProvider.js'
+import type { WalletProvider } from '@/wallet/core/providers/WalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWallet.js'
 /**
@@ -63,6 +65,21 @@ export class WalletNamespace<
     params: CreateSmartWalletOptions,
   ): Promise<SmartWallet> {
     return this.provider.createSmartWallet(params)
+  }
+
+  /**
+   * Create a viem LocalAccount signer from the hosted wallet
+   * @description Produces a signing account backed by the hosted wallet without wrapping
+   * it in a full Verbs wallet. This is useful when you need to pass the signer
+   * into a Verbs smart wallet as a signer, for lower-level viem operations, or
+   * for passing to other libraries that accept a viem `LocalAccount`.
+   * @param params - Configuration for the signer
+   * @returns Promise resolving to a viem `LocalAccount` with the hosted wallet as the signer backend
+   */
+  async createSigner(
+    params: TToVerbsMap[THostedProviderType],
+  ): Promise<LocalAccount> {
+    return this.provider.createSigner(params)
   }
 
   /**

--- a/packages/sdk/src/wallet/core/providers/WalletProvider.ts
+++ b/packages/sdk/src/wallet/core/providers/WalletProvider.ts
@@ -1,4 +1,4 @@
-import { getAddress } from 'viem'
+import { getAddress, type LocalAccount } from 'viem'
 
 import type {
   CreateSmartWalletOptions,
@@ -62,6 +62,21 @@ export class WalletProvider<
     params: TToVerbsMap[THostedProviderType],
   ): Promise<Wallet> {
     return this.hostedWalletProvider.toVerbsWallet(params)
+  }
+
+  /**
+   * Create a viem LocalAccount signer from the hosted wallet
+   * @description Produces a signing account backed by the hosted wallet without wrapping
+   * it in a full Verbs wallet. This is useful when you need to pass the signer
+   * into a Verbs smart wallet as a signer, for lower-level viem operations, or
+   * for passing to other libraries that accept a viem `LocalAccount`.
+   * @param params - Configuration for the signer
+   * @returns Promise resolving to a viem `LocalAccount` with the hosted wallet as the signer backend
+   */
+  async createSigner(
+    params: TToVerbsMap[THostedProviderType],
+  ): Promise<LocalAccount> {
+    return this.hostedWalletProvider.createSigner(params)
   }
 
   /**

--- a/packages/sdk/src/wallet/core/providers/hosted/abstract/HostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/core/providers/hosted/abstract/HostedWalletProvider.ts
@@ -1,3 +1,5 @@
+import type { LocalAccount } from 'viem'
+
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 
@@ -23,4 +25,15 @@ export abstract class HostedWalletProvider<
    * @returns Promise resolving to the Verbs wallet instance
    */
   abstract toVerbsWallet(params: TOptionsMap[TType]): Promise<Wallet>
+
+  /**
+   * Create a viem LocalAccount signer from the hosted wallet
+   * @description Produces a signing account backed by the hosted wallet without wrapping
+   * it in a full Verbs wallet. This is useful when you need to pass the signer
+   * into a Verbs smart wallet as a signer, for lower-level viem operations, or
+   * for passing to other libraries that accept a viem `LocalAccount`.
+   * @param params - Configuration for the signer
+   * @returns Promise resolving to a viem `LocalAccount` with the hosted wallet as the signer backend
+   */
+  abstract createSigner(params: TOptionsMap[TType]): Promise<LocalAccount>
 }

--- a/packages/sdk/src/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.ts
@@ -1,4 +1,5 @@
 import type { PrivyClient } from '@privy-io/server-auth'
+import type { LocalAccount } from 'viem'
 import { getAddress } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
@@ -9,6 +10,7 @@ import type {
   PrivyHostedWalletToVerbsWalletOptions,
 } from '@/wallet/node/providers/hosted/types/index.js'
 import { PrivyWallet } from '@/wallet/node/wallets/hosted/privy/PrivyWallet.js'
+import { createSigner } from '@/wallet/node/wallets/hosted/privy/utils/createSigner.js'
 
 /**
  * Privy wallet provider implementation
@@ -38,5 +40,23 @@ export class PrivyHostedWalletProvider extends HostedWalletProvider<
       address: getAddress(params.address),
       chainManager: this.chainManager,
     })
+  }
+
+  /**
+   * Create a LocalAccount from this Privy wallet
+   * @description Converts the Privy wallet into a viem-compatible LocalAccount that can sign
+   * messages and transactions. The returned account uses Privy's signing infrastructure
+   * under the hood while providing a standard viem interface.
+   * @param params - Privy configuration for the signer
+   * @param params.privyClient - Privy client instance
+   * @param params.walletId - Privy wallet identifier
+   * @param params.address - Ethereum address of the wallet
+   * @returns Promise resolving to a LocalAccount configured for signing operations
+   * @throws Error if wallet retrieval fails or signing operations are not supported
+   */
+  async createSigner(
+    params: NodeToVerbsOptionsMap['privy'],
+  ): Promise<LocalAccount> {
+    return createSigner({ ...params, privyClient: this.privyClient })
   }
 }

--- a/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
@@ -37,14 +37,10 @@ export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegist
       type: 'turnkey',
       validateOptions(options): options is NodeOptionsMap['turnkey'] {
         const o = options as NodeOptionsMap['turnkey']
-        return Boolean(o?.client) && typeof o?.organizationId === 'string'
+        return Boolean(o?.client)
       },
       create({ chainManager }, options) {
-        return new TurnkeyHostedWalletProvider(
-          options.client,
-          options.organizationId,
-          chainManager,
-        )
+        return new TurnkeyHostedWalletProvider(options.client, chainManager)
       },
     })
   }

--- a/packages/sdk/src/wallet/node/providers/hosted/registry/__tests__/NodeHostedWalletProviderRegistry.spec.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/registry/__tests__/NodeHostedWalletProviderRegistry.spec.ts
@@ -59,13 +59,10 @@ describe('NodeHostedWalletProviderRegistry', () => {
     expect(
       factory.validateOptions?.({
         client: mockTurnkeyClient,
-        organizationId: 'org_123',
       } as NodeOptionsMap['turnkey']),
     ).toBe(true)
     // Invalid shape should not pass validation
     expect(factory.validateOptions?.({})).toBe(false)
-    expect(factory.validateOptions?.({ client: mockTurnkeyClient })).toBe(false)
-    expect(factory.validateOptions?.({ organizationId: 'org_123' })).toBe(false)
   })
 
   it('creates a TurnkeyHostedWalletProvider instance', () => {
@@ -76,7 +73,6 @@ describe('NodeHostedWalletProviderRegistry', () => {
       { chainManager: mockChainManager },
       {
         client: mockTurnkeyClient,
-        organizationId: 'org_123',
       },
     )
 

--- a/packages/sdk/src/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
@@ -1,12 +1,14 @@
 import type { TurnkeySDKClientBase } from '@turnkey/core'
 import type { TurnkeyClient as TurnkeyHttpClient } from '@turnkey/http'
 import type { TurnkeyServerClient } from '@turnkey/sdk-server'
+import type { LocalAccount } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { NodeToVerbsOptionsMap } from '@/wallet/node/providers/hosted/types/index.js'
 import { TurnkeyWallet } from '@/wallet/node/wallets/hosted/turnkey/TurnkeyWallet.js'
+import { createSigner } from '@/wallet/node/wallets/hosted/turnkey/utils/createSigner.js'
 
 /**
  * Turnkey wallet provider implementation
@@ -22,7 +24,6 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
   /**
    * Create a new Turnkey wallet provider
    * @param client - Turnkey client instance (HTTP, server, or core SDK base)
-   * @param organizationId - Turnkey organization ID that owns the signing key
    * @param chainManager - Chain manager used to resolve chains and RPC transports
    */
   constructor(
@@ -30,7 +31,6 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
       | TurnkeyHttpClient
       | TurnkeyServerClient
       | TurnkeySDKClientBase,
-    private readonly organizationId: string,
     chainManager: ChainManager,
   ) {
     super(chainManager)
@@ -50,10 +50,32 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
   ): Promise<Wallet> {
     return TurnkeyWallet.create({
       client: this.client,
-      organizationId: this.organizationId,
+      organizationId: params.organizationId,
       signWith: params.signWith,
       ethereumAddress: params.ethereumAddress,
       chainManager: this.chainManager,
+    })
+  }
+
+  /**
+   * Create a viem LocalAccount signer from Turnkey credentials
+   * @description Produces a signing account backed by Turnkey without wrapping
+   * it in a full Verbs wallet. This is useful when you need to pass the signer
+   * into a Verbs smart wallet as a signer, for lower-level viem operations, or
+   * for passing to other libraries that accept a viem `LocalAccount`.
+   * @param params - Turnkey configuration for the signer
+   * @param params.client - Turnkey client instance
+   * @param params.organizationId - Turnkey organization ID that owns the signing key
+   * @param params.signWith - Wallet account address, private key address, or private key ID
+   * @param params.ethereumAddress - Optional Ethereum address (recommended for passkey clients to avoid extra prompts)
+   * @returns Promise resolving to a viem `LocalAccount` with Turnkey as the signer backend
+   */
+  async createSigner(
+    params: NodeToVerbsOptionsMap['turnkey'],
+  ): Promise<LocalAccount> {
+    return createSigner({
+      ...params,
+      client: this.client,
     })
   }
 }

--- a/packages/sdk/src/wallet/node/providers/hosted/types/index.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/types/index.ts
@@ -2,6 +2,7 @@ import type { PrivyClient } from '@privy-io/server-auth'
 import type { TurnkeySDKClientBase } from '@turnkey/core'
 import type { TurnkeyClient as TurnkeyHttpClient } from '@turnkey/http'
 import type { TurnkeyServerClient } from '@turnkey/sdk-server'
+import type { Address } from 'viem'
 
 import type { HostedWalletProvidersSchema } from '@/wallet/core/providers/hosted/types/index.js'
 import type { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
@@ -37,7 +38,6 @@ export interface NodeOptionsMap {
    */
   turnkey: {
     client: TurnkeyHttpClient | TurnkeyServerClient | TurnkeySDKClientBase
-    organizationId: string
   }
 }
 
@@ -51,6 +51,7 @@ export interface NodeOptionsMap {
  * undefined if using an API key client.
  */
 export type TurnkeyHostedWalletToVerbsWalletOptions = {
+  organizationId: string
   signWith: string
   ethereumAddress?: string
 }
@@ -63,7 +64,7 @@ export type TurnkeyHostedWalletToVerbsWalletOptions = {
  */
 export type PrivyHostedWalletToVerbsWalletOptions = {
   walletId: string
-  address: string
+  address: Address
 }
 
 /**

--- a/packages/sdk/src/wallet/node/wallets/hosted/privy/PrivyWallet.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/privy/PrivyWallet.ts
@@ -1,9 +1,5 @@
 import type { PrivyClient } from '@privy-io/server-auth'
 import {
-  createViemAccount,
-  type GetViemAccountInputType,
-} from '@privy-io/server-auth/viem'
-import {
   type Address,
   createWalletClient,
   fallback,
@@ -15,6 +11,7 @@ import {
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import { createSigner } from '@/wallet/node/wallets/hosted/privy/utils/createSigner.js'
 
 /**
  * Privy wallet implementation
@@ -84,7 +81,7 @@ export class PrivyWallet extends Wallet {
    * Initialize the PrivyWallet by creating the signer account
    */
   protected async performInitialization() {
-    this.signer = await this.createAccount()
+    this.signer = await this.createSigner()
   }
 
   /**
@@ -95,13 +92,11 @@ export class PrivyWallet extends Wallet {
    * @returns Promise resolving to a LocalAccount configured for signing operations
    * @throws Error if wallet retrieval fails or signing operations are not supported
    */
-  private async createAccount(): Promise<LocalAccount> {
-    const account = await createViemAccount({
+  private async createSigner(): Promise<LocalAccount> {
+    return createSigner({
       walletId: this.walletId,
       address: this.address,
-      // TODO: Fix this type error
-      privy: this.privyClient as unknown as GetViemAccountInputType['privy'],
+      privyClient: this.privyClient,
     })
-    return account
   }
 }

--- a/packages/sdk/src/wallet/node/wallets/hosted/privy/utils/__tests__/createSigner.spec.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/privy/utils/__tests__/createSigner.spec.ts
@@ -1,0 +1,48 @@
+import { createViemAccount } from '@privy-io/server-auth/viem'
+import type { Address, LocalAccount } from 'viem'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMockPrivyClient } from '@/test/MockPrivyClient.js'
+import { getRandomAddress } from '@/test/utils.js'
+import { createSigner } from '@/wallet/node/wallets/hosted/privy/utils/createSigner.js'
+
+vi.mock('@privy-io/server-auth/viem', async () => ({
+  // @ts-ignore - importActual returns unknown
+  ...(await vi.importActual('@privy-io/server-auth/viem')),
+  createViemAccount: vi.fn(),
+}))
+
+describe('createSigner (Node Privy)', () => {
+  const mockAddress = getRandomAddress()
+  const mockPrivyClient = createMockPrivyClient(
+    'test-app-id',
+    'test-app-secret',
+  )
+  const mockLocalAccount = {
+    address: mockAddress,
+    signMessage: vi.fn(),
+    sign: vi.fn(),
+    signTransaction: vi.fn(),
+    signTypedData: vi.fn(),
+  } as unknown as LocalAccount
+
+  it('should create a LocalAccount with correct configuration', async () => {
+    const createdWallet = await mockPrivyClient.walletApi.createWallet({
+      chainType: 'ethereum',
+    })
+    vi.mocked(createViemAccount).mockResolvedValue(mockLocalAccount)
+
+    const signer = await createSigner({
+      privyClient: mockPrivyClient,
+      walletId: createdWallet.id,
+      address: createdWallet.address as Address,
+    })
+
+    expect(createViemAccount).toHaveBeenCalledWith({
+      walletId: createdWallet.id,
+      address: createdWallet.address,
+      privy: mockPrivyClient,
+    })
+    expect(signer).toBe(mockLocalAccount)
+  })
+})

--- a/packages/sdk/src/wallet/node/wallets/hosted/privy/utils/createSigner.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/privy/utils/createSigner.ts
@@ -1,0 +1,32 @@
+import type { GetViemAccountInputType } from '@privy-io/server-auth/viem'
+import { createViemAccount } from '@privy-io/server-auth/viem'
+import type { LocalAccount } from 'viem'
+
+import type {
+  NodeOptionsMap,
+  PrivyHostedWalletToVerbsWalletOptions,
+} from '@/wallet/node/providers/hosted/types/index.js'
+
+/**
+ * Create a LocalAccount from a Privy wallet
+ * @description Converts the Privy wallet into a viem-compatible LocalAccount that can sign
+ * messages and transactions. The returned account uses Privy's signing infrastructure
+ * under the hood while providing a standard viem interface.
+ * @param params.walletId - Privy wallet identifier
+ * @param params.address - Ethereum address of the wallet
+ * @param params.privyClient - Privy client instance
+ * @returns Promise resolving to a LocalAccount configured for signing operations
+ * @throws Error if wallet retrieval fails or signing operations are not supported
+ */
+export async function createSigner(
+  params: PrivyHostedWalletToVerbsWalletOptions & NodeOptionsMap['privy'],
+): Promise<LocalAccount> {
+  const { walletId, address, privyClient } = params
+  const account = await createViemAccount({
+    walletId,
+    address,
+    // TODO: Fix this type error
+    privy: privyClient as unknown as GetViemAccountInputType['privy'],
+  })
+  return account
+}

--- a/packages/sdk/src/wallet/node/wallets/hosted/turnkey/TurnkeyWallet.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/turnkey/TurnkeyWallet.ts
@@ -1,13 +1,13 @@
 import type { TurnkeySDKClientBase } from '@turnkey/core'
 import type { TurnkeyClient } from '@turnkey/http'
 import type { TurnkeyServerClient } from '@turnkey/sdk-server'
-import { createAccount } from '@turnkey/viem'
 import type { Address, LocalAccount, WalletClient } from 'viem'
 import { createWalletClient, fallback, http } from 'viem'
 
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import { createSigner } from '@/wallet/node/wallets/hosted/turnkey/utils/createSigner.js'
 
 /**
  * Turnkey wallet implementation
@@ -79,12 +79,12 @@ export class TurnkeyWallet extends Wallet {
   }
 
   protected async performInitialization() {
-    this.signer = await this.createAccount()
+    this.signer = await this.createSigner()
     this.address = this.signer.address
   }
 
-  private async createAccount(): Promise<LocalAccount> {
-    return createAccount({
+  private async createSigner(): Promise<LocalAccount> {
+    return createSigner({
       client: this.client,
       organizationId: this.organizationId,
       signWith: this.signWith,

--- a/packages/sdk/src/wallet/node/wallets/hosted/turnkey/utils/__tests__/createSigner.spec.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/turnkey/utils/__tests__/createSigner.spec.ts
@@ -1,0 +1,77 @@
+import type { TurnkeySDKClientBase } from '@turnkey/core'
+import type { TurnkeyClient as TurnkeyHttpClient } from '@turnkey/http'
+import type { TurnkeyServerClient } from '@turnkey/sdk-server'
+import { createAccount } from '@turnkey/viem'
+import type { LocalAccount } from 'viem'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getRandomAddress } from '@/test/utils.js'
+import { createSigner } from '@/wallet/node/wallets/hosted/turnkey/utils/createSigner.js'
+
+vi.mock('@turnkey/viem', async () => ({
+  createAccount: vi.fn(),
+}))
+
+function createMockTurnkeyClient():
+  | TurnkeyHttpClient
+  | TurnkeyServerClient
+  | TurnkeySDKClientBase {
+  return {
+    // minimal shape for typing; createAccount uses this via @turnkey/viem
+  } as unknown as TurnkeyHttpClient
+}
+
+describe('createSigner (Node Turnkey)', () => {
+  const mockAddress = getRandomAddress()
+
+  it('should create a LocalAccount with correct configuration', async () => {
+    const mockLocalAccount = {
+      address: mockAddress,
+      signMessage: vi.fn(),
+      sign: vi.fn(),
+      signTransaction: vi.fn(),
+      signTypedData: vi.fn(),
+    } as unknown as LocalAccount
+    vi.mocked(createAccount).mockResolvedValue(mockLocalAccount)
+
+    const client = createMockTurnkeyClient()
+    const signer = await createSigner({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+    })
+
+    expect(createAccount).toHaveBeenCalledWith({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+      ethereumAddress: undefined,
+    })
+    expect(signer).toBe(mockLocalAccount)
+  })
+
+  it('should pass ethereumAddress when provided', async () => {
+    const mockLocalAccount = {
+      address: mockAddress,
+      type: 'local',
+    } as unknown as LocalAccount
+    vi.mocked(createAccount).mockResolvedValue(mockLocalAccount)
+
+    const client = createMockTurnkeyClient()
+    const ethereumAddress = getRandomAddress()
+    const signer = await createSigner({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+      ethereumAddress,
+    })
+
+    expect(createAccount).toHaveBeenCalledWith({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+      ethereumAddress,
+    })
+    expect(signer).toBe(mockLocalAccount)
+  })
+})

--- a/packages/sdk/src/wallet/node/wallets/hosted/turnkey/utils/createSigner.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/turnkey/utils/createSigner.ts
@@ -1,0 +1,32 @@
+import { createAccount } from '@turnkey/viem'
+import type { LocalAccount } from 'viem'
+
+import type {
+  NodeOptionsMap,
+  TurnkeyHostedWalletToVerbsWalletOptions,
+} from '@/wallet/node/providers/hosted/types/index.js'
+
+/**
+ * Create a viem LocalAccount instance backed by Turnkey
+ * @description Wraps the Turnkey SDK's `createAccount` to produce a signing
+ * account compatible with viem. Under the hood, this uses the provided
+ * `client`, `organizationId`, and `signWith` to authenticate signing requests
+ * with Turnkey. If `ethereumAddress` is supplied, it's used directly;
+ * otherwise the SDK fetches it from the Turnkey API.
+ * @param params.client - Turnkey client instance
+ * @param params.organizationId - Turnkey organization ID that owns the signing key
+ * @param params.signWith - Wallet account address, private key address, or private key ID
+ * @param params.ethereumAddress - Ethereum address to use for this account, in the case that a private key ID is used to sign.
+ * @returns Promise resolving to a viem `LocalAccount` with Turnkey as the signer backend
+ */
+export async function createSigner(
+  params: TurnkeyHostedWalletToVerbsWalletOptions & NodeOptionsMap['turnkey'],
+): Promise<LocalAccount> {
+  const { client, organizationId, signWith, ethereumAddress } = params
+  return createAccount({
+    client,
+    organizationId,
+    signWith,
+    ethereumAddress,
+  })
+}

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.ts
@@ -1,11 +1,11 @@
+import type { LocalAccount } from 'viem'
+
 import type { ChainManager } from '@/services/ChainManager.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
-import type {
-  DynamicHostedWalletToVerbsWalletOptions,
-  ReactToVerbsOptionsMap,
-} from '@/wallet/react/providers/hosted/types/index.js'
+import type { ReactToVerbsOptionsMap } from '@/wallet/react/providers/hosted/types/index.js'
 import { DynamicWallet } from '@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js'
+import { createSigner } from '@/wallet/react/wallets/hosted/dynamic/utils/createSigner.js'
 
 /**
  * Dynamic wallet provider implementation
@@ -23,11 +23,27 @@ export class DynamicHostedWalletProvider extends HostedWalletProvider<
   }
 
   async toVerbsWallet(
-    params: DynamicHostedWalletToVerbsWalletOptions,
+    params: ReactToVerbsOptionsMap['dynamic'],
   ): Promise<Wallet> {
     return DynamicWallet.create({
       dynamicWallet: params.wallet,
       chainManager: this.chainManager,
     })
+  }
+
+  /**
+   * Create a viem LocalAccount signer from Dynamic credentials
+   * @description Produces a signing account backed by Dynamic without wrapping
+   * it in a full Verbs wallet. This is useful when you need to pass the signer
+   * into a Verbs smart wallet as a signer, for lower-level viem operations, or
+   * for passing to other libraries that accept a viem `LocalAccount`.
+   * @param params - Dynamic configuration for the signer
+   * @param params.wallet - Dynamic wallet instance
+   * @returns Promise resolving to a viem `LocalAccount` with Dynamic as the signer backend
+   */
+  async createSigner(
+    params: ReactToVerbsOptionsMap['dynamic'],
+  ): Promise<LocalAccount> {
+    return createSigner(params)
   }
 }

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/__mocks__/DynamicHostedWalletProviderMock.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/__mocks__/DynamicHostedWalletProviderMock.ts
@@ -1,3 +1,4 @@
+import type { LocalAccount } from 'viem'
 import { unichain } from 'viem/op-stack'
 import { vi } from 'vitest'
 
@@ -27,6 +28,14 @@ export class DynamicHostedWalletProviderMock extends HostedWalletProvider<
     },
   )
 
+  public readonly createSignerMock = vi.fn(
+    async (
+      _params: DynamicHostedWalletToVerbsWalletOptions,
+    ): Promise<LocalAccount> => {
+      return {} as unknown as LocalAccount
+    },
+  )
+
   constructor() {
     const mockChainManager = new MockChainManager({
       supportedChains: [unichain.id],
@@ -38,5 +47,11 @@ export class DynamicHostedWalletProviderMock extends HostedWalletProvider<
     params: DynamicHostedWalletToVerbsWalletOptions,
   ): Promise<Wallet> {
     return this.toVerbsWalletMock(params)
+  }
+
+  async createSigner(
+    params: DynamicHostedWalletToVerbsWalletOptions,
+  ): Promise<LocalAccount> {
+    return this.createSignerMock(params)
   }
 }

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/__tests__/DynamicHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/__tests__/DynamicHostedWalletProvider.spec.ts
@@ -1,9 +1,11 @@
+import type { LocalAccount } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
 import type { DynamicHostedWalletToVerbsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
+import * as createSignerUtil from '@/wallet/react/wallets/hosted/dynamic/utils/createSigner.js'
 
 // Mock DynamicWallet module to avoid importing browser-related deps
 vi.mock('@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js', () => {
@@ -12,28 +14,58 @@ vi.mock('@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js', () => {
 })
 const { DynamicWallet } = (await import(
   '@/wallet/react/wallets/hosted/dynamic/DynamicWallet.js'
-)) as any
+)) as unknown as { DynamicWallet: { create: ReturnType<typeof vi.fn> } }
 
 describe('DynamicHostedWalletProvider', () => {
-  it('toVerbsWallet delegates to DynamicWallet.create with correct args', async () => {
-    const mockChainManager = new MockChainManager({
-      supportedChains: [1],
-    }) as unknown as ChainManager
-    const provider = new DynamicHostedWalletProvider(mockChainManager)
+  describe('toVerbsWallet', () => {
+    it('toVerbsWallet delegates to DynamicWallet.create with correct args', async () => {
+      const mockChainManager = new MockChainManager({
+        supportedChains: [1],
+      }) as unknown as ChainManager
+      const provider = new DynamicHostedWalletProvider(mockChainManager)
 
-    const mockDynamicWallet = {
-      __brand: 'dynamic-wallet',
-    } as unknown as DynamicHostedWalletToVerbsWalletOptions['wallet']
-    const mockResult = { __brand: 'verbs-wallet' }
-    vi.mocked(DynamicWallet.create).mockResolvedValueOnce(mockResult)
+      const mockDynamicWallet = {
+        __brand: 'dynamic-wallet',
+      } as unknown as DynamicHostedWalletToVerbsWalletOptions['wallet']
+      const mockResult = { __brand: 'verbs-wallet' }
+      vi.mocked(DynamicWallet.create).mockResolvedValueOnce(mockResult)
 
-    const result = await provider.toVerbsWallet({ wallet: mockDynamicWallet })
+      const result = await provider.toVerbsWallet({ wallet: mockDynamicWallet })
 
-    expect(DynamicWallet.create).toHaveBeenCalledTimes(1)
-    expect(DynamicWallet.create).toHaveBeenCalledWith({
-      dynamicWallet: mockDynamicWallet,
-      chainManager: mockChainManager,
+      expect(DynamicWallet.create).toHaveBeenCalledTimes(1)
+      expect(DynamicWallet.create).toHaveBeenCalledWith({
+        dynamicWallet: mockDynamicWallet,
+        chainManager: mockChainManager,
+      })
+      expect(result).toBe(mockResult)
     })
-    expect(result).toBe(mockResult)
+  })
+
+  describe('createSigner', () => {
+    it('should delegate to createSigner utility with correct params', async () => {
+      const mockChainManager = new MockChainManager({
+        supportedChains: [1],
+      }) as unknown as ChainManager
+      const provider = new DynamicHostedWalletProvider(mockChainManager)
+
+      const mockDynamicWallet = {
+        __brand: 'dynamic-wallet',
+      } as unknown as DynamicHostedWalletToVerbsWalletOptions['wallet']
+
+      const mockSigner = {
+        address: '0xabc',
+        type: 'local',
+      } as unknown as LocalAccount
+
+      const createSignerSpy = vi
+        .spyOn(createSignerUtil, 'createSigner')
+        .mockResolvedValueOnce(mockSigner)
+
+      const params = { wallet: mockDynamicWallet }
+      const signer = await provider.createSigner(params)
+
+      expect(createSignerSpy).toHaveBeenCalledWith(params)
+      expect(signer).toBe(mockSigner)
+    })
   })
 })

--- a/packages/sdk/src/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.ts
@@ -1,8 +1,11 @@
+import type { LocalAccount } from 'viem'
+
 import type { ChainManager } from '@/services/ChainManager.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { ReactToVerbsOptionsMap } from '@/wallet/react/providers/hosted/types/index.js'
 import { PrivyWallet } from '@/wallet/react/wallets/hosted/privy/PrivyWallet.js'
+import { createSigner } from '@/wallet/react/wallets/hosted/privy/utils/createSigner.js'
 
 /**
  * Privy hosted wallet provider (React)
@@ -28,5 +31,21 @@ export class PrivyHostedWalletProvider extends HostedWalletProvider<
       connectedWallet,
     })
     return wallet
+  }
+
+  /**
+   * Create a viem LocalAccount signer from Privy credentials
+   * @description Produces a signing account backed by Privy without wrapping
+   * it in a full Verbs wallet. This is useful when you need to pass the signer
+   * into a Verbs smart wallet as a signer, for lower-level viem operations, or
+   * for passing to other libraries that accept a viem `LocalAccount`.
+   * @param params - Privy configuration for the signer
+   * @param params.connectedWallet - Privy connected wallet
+   * @returns Promise resolving to a viem `LocalAccount` with Privy as the signer backend
+   */
+  async createSigner(
+    params: ReactToVerbsOptionsMap['privy'],
+  ): Promise<LocalAccount> {
+    return createSigner(params)
   }
 }

--- a/packages/sdk/src/wallet/react/providers/hosted/privy/__mocks__/PrivyHostedWalletProviderMock.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/privy/__mocks__/PrivyHostedWalletProviderMock.ts
@@ -1,3 +1,4 @@
+import type { LocalAccount } from 'node_modules/viem/_types/accounts/types.js'
 import { unichain } from 'viem/op-stack'
 import { vi } from 'vitest'
 
@@ -24,6 +25,14 @@ export class PrivyHostedWalletProviderMock extends HostedWalletProvider<
     },
   )
 
+  public readonly createSignerMock = vi.fn(
+    async (
+      _params: PrivyHostedWalletToVerbsWalletOptions,
+    ): Promise<LocalAccount> => {
+      return {} as unknown as LocalAccount
+    },
+  )
+
   constructor() {
     const mockChainManager = new MockChainManager({
       supportedChains: [unichain.id],
@@ -35,5 +44,11 @@ export class PrivyHostedWalletProviderMock extends HostedWalletProvider<
     params: PrivyHostedWalletToVerbsWalletOptions,
   ): Promise<Wallet> {
     return this.toVerbsWalletMock(params)
+  }
+
+  async createSigner(
+    params: PrivyHostedWalletToVerbsWalletOptions,
+  ): Promise<LocalAccount> {
+    return this.createSignerMock(params)
   }
 }

--- a/packages/sdk/src/wallet/react/providers/hosted/privy/__tests__/PrivyHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/privy/__tests__/PrivyHostedWalletProvider.spec.ts
@@ -1,10 +1,12 @@
 import type { ConnectedWallet } from '@privy-io/react-auth'
+import type { LocalAccount } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { PrivyHostedWalletProvider } from '@/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.js'
 import { PrivyWallet } from '@/wallet/react/wallets/hosted/privy/PrivyWallet.js'
+import * as createSignerUtil from '@/wallet/react/wallets/hosted/privy/utils/createSigner.js'
 
 // Mock PrivyWallet to avoid importing browser-related deps
 vi.mock('@/wallet/react/wallets/hosted/privy/PrivyWallet.js', async () => {
@@ -15,28 +17,58 @@ vi.mock('@/wallet/react/wallets/hosted/privy/PrivyWallet.js', async () => {
 })
 
 describe('PrivyHostedWalletProvider (React)', () => {
-  it('toVerbsWallet delegates to PrivyWallet.create with correct args', async () => {
-    const mockChainManager = new MockChainManager({
-      supportedChains: [1],
-    }) as unknown as ChainManager
-    const provider = new PrivyHostedWalletProvider(mockChainManager)
-    const mockVerbsWallet = {
-      __brand: 'verbs-wallet',
-    } as unknown as PrivyWallet
-    const mockConnectedWallet = {
-      __brand: 'privy-connected-wallet',
-    } as unknown as ConnectedWallet
-    vi.mocked(PrivyWallet.create).mockResolvedValueOnce(mockVerbsWallet)
+  describe('toVerbsWallet', () => {
+    it('toVerbsWallet delegates to PrivyWallet.create with correct args', async () => {
+      const mockChainManager = new MockChainManager({
+        supportedChains: [1],
+      }) as unknown as ChainManager
+      const provider = new PrivyHostedWalletProvider(mockChainManager)
+      const mockVerbsWallet = {
+        __brand: 'verbs-wallet',
+      } as unknown as PrivyWallet
+      const mockConnectedWallet = {
+        __brand: 'privy-connected-wallet',
+      } as unknown as ConnectedWallet
+      vi.mocked(PrivyWallet.create).mockResolvedValueOnce(mockVerbsWallet)
 
-    const result = await provider.toVerbsWallet({
-      connectedWallet: mockConnectedWallet,
-    })
+      const result = await provider.toVerbsWallet({
+        connectedWallet: mockConnectedWallet,
+      })
 
-    expect(PrivyWallet.create).toHaveBeenCalledTimes(1)
-    expect(PrivyWallet.create).toHaveBeenCalledWith({
-      chainManager: mockChainManager,
-      connectedWallet: mockConnectedWallet,
+      expect(PrivyWallet.create).toHaveBeenCalledTimes(1)
+      expect(PrivyWallet.create).toHaveBeenCalledWith({
+        chainManager: mockChainManager,
+        connectedWallet: mockConnectedWallet,
+      })
+      expect(result).toBe(mockVerbsWallet)
     })
-    expect(result).toBe(mockVerbsWallet)
+  })
+
+  describe('createSigner', () => {
+    it('should delegate to createSigner utility with correct params', async () => {
+      const mockChainManager = new MockChainManager({
+        supportedChains: [1],
+      }) as unknown as ChainManager
+      const provider = new PrivyHostedWalletProvider(mockChainManager)
+
+      const mockConnectedWallet = {
+        __brand: 'privy-connected-wallet',
+      } as unknown as ConnectedWallet
+
+      const mockSigner = {
+        address: '0xabc',
+        type: 'local',
+      } as unknown as LocalAccount
+
+      const createSignerSpy = vi
+        .spyOn(createSignerUtil, 'createSigner')
+        .mockResolvedValueOnce(mockSigner)
+
+      const params = { connectedWallet: mockConnectedWallet }
+      const signer = await provider.createSigner(params)
+
+      expect(createSignerSpy).toHaveBeenCalledWith(params)
+      expect(signer).toBe(mockSigner)
+    })
   })
 })

--- a/packages/sdk/src/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
@@ -1,8 +1,11 @@
+import type { LocalAccount } from 'viem'
+
 import type { ChainManager } from '@/services/ChainManager.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { ReactToVerbsOptionsMap } from '@/wallet/react/providers/hosted/types/index.js'
 import { TurnkeyWallet } from '@/wallet/react/wallets/hosted/turnkey/TurnkeyWallet.js'
+import { createSigner } from '@/wallet/react/wallets/hosted/turnkey/utils/createSigner.js'
 
 /**
  * Turnkey wallet provider implementation
@@ -47,5 +50,24 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
       ethereumAddress,
       chainManager: this.chainManager,
     })
+  }
+
+  /**
+   * Create a viem LocalAccount signer from Turnkey credentials
+   * @description Produces a signing account backed by Turnkey without wrapping
+   * it in a full Verbs wallet. This is useful when you need to pass the signer
+   * into a Verbs smart wallet as an owner, for lower-level viem operations, or
+   * for passing to other libraries that accept a viem `LocalAccount`.
+   * @param params - Turnkey configuration for the signer
+   * @param params.client - Turnkey client instance
+   * @param params.organizationId - Turnkey organization ID that owns the signing key
+   * @param params.signWith - Wallet account address, private key address, or private key ID
+   * @param params.ethereumAddress - Optional Ethereum address (recommended for passkey clients to avoid extra prompts)
+   * @returns Promise resolving to a viem `LocalAccount` with Turnkey as the signer backend
+   */
+  async createSigner(
+    params: ReactToVerbsOptionsMap['turnkey'],
+  ): Promise<LocalAccount> {
+    return createSigner(params)
   }
 }

--- a/packages/sdk/src/wallet/react/providers/hosted/turnkey/__tests__/TurnkeyHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/turnkey/__tests__/TurnkeyHostedWalletProvider.spec.ts
@@ -1,4 +1,5 @@
 import type { TurnkeySDKClientBase } from '@turnkey/react-wallet-kit'
+import type { LocalAccount } from 'viem'
 import { unichain } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -6,79 +7,109 @@ import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { TurnkeyHostedWalletProvider } from '@/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
 import { TurnkeyWallet } from '@/wallet/react/wallets/hosted/turnkey/TurnkeyWallet.js'
+import * as createSignerUtil from '@/wallet/react/wallets/hosted/turnkey/utils/createSigner.js'
 
 describe('TurnkeyHostedWalletProvider', () => {
   const mockChainManager = new MockChainManager({
     supportedChains: [unichain.id],
   }) as unknown as ChainManager
 
-  it('forwards params to TurnkeyWallet.create', async () => {
-    const turnkeyClient = {} as unknown as TurnkeySDKClientBase
-    const provider = new TurnkeyHostedWalletProvider(mockChainManager)
-    const spyTurnkeyWalletCreate = vi
-      .spyOn(TurnkeyWallet, 'create')
-      .mockResolvedValueOnce({
-        address: '0xabc',
-      } as unknown as TurnkeyWallet)
+  describe('toVerbsWallet', () => {
+    it('forwards params to TurnkeyWallet.create', async () => {
+      const turnkeyClient = {} as unknown as TurnkeySDKClientBase
+      const provider = new TurnkeyHostedWalletProvider(mockChainManager)
+      const spyTurnkeyWalletCreate = vi
+        .spyOn(TurnkeyWallet, 'create')
+        .mockResolvedValueOnce({
+          address: '0xabc',
+        } as unknown as TurnkeyWallet)
 
-    await provider.toVerbsWallet({
-      client: turnkeyClient,
-      organizationId: 'org_123',
-      signWith: 'key_abc',
-    })
-
-    expect(spyTurnkeyWalletCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
+      await provider.toVerbsWallet({
         client: turnkeyClient,
         organizationId: 'org_123',
         signWith: 'key_abc',
-        ethereumAddress: undefined,
-        chainManager: mockChainManager,
-      }),
-    )
-  })
+      })
 
-  it('forwards ethereumAddress when provided', async () => {
-    const turnkeyClient = {} as unknown as TurnkeySDKClientBase
-    const provider = new TurnkeyHostedWalletProvider(mockChainManager)
-    const spyTurnkeyWalletCreate = vi
-      .spyOn(TurnkeyWallet, 'create')
-      .mockResolvedValueOnce({
-        address: '0xabc',
-      } as unknown as TurnkeyWallet)
-
-    await provider.toVerbsWallet({
-      client: turnkeyClient,
-      organizationId: 'org_123',
-      signWith: 'key_abc',
-      ethereumAddress: '0x123',
+      expect(spyTurnkeyWalletCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client: turnkeyClient,
+          organizationId: 'org_123',
+          signWith: 'key_abc',
+          ethereumAddress: undefined,
+          chainManager: mockChainManager,
+        }),
+      )
     })
 
-    expect(spyTurnkeyWalletCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
+    it('forwards ethereumAddress when provided', async () => {
+      const turnkeyClient = {} as unknown as TurnkeySDKClientBase
+      const provider = new TurnkeyHostedWalletProvider(mockChainManager)
+      const spyTurnkeyWalletCreate = vi
+        .spyOn(TurnkeyWallet, 'create')
+        .mockResolvedValueOnce({
+          address: '0xabc',
+        } as unknown as TurnkeyWallet)
+
+      await provider.toVerbsWallet({
         client: turnkeyClient,
         organizationId: 'org_123',
         signWith: 'key_abc',
         ethereumAddress: '0x123',
-        chainManager: mockChainManager,
-      }),
-    )
-  })
+      })
 
-  it('returns the created TurnkeyWallet instance', async () => {
-    const turnkeyClient = {} as unknown as TurnkeySDKClientBase
-    const provider = new TurnkeyHostedWalletProvider(mockChainManager)
-    const fakeWallet = {
-      address: '0xabc',
-    } as unknown as TurnkeyWallet
-    vi.spyOn(TurnkeyWallet, 'create').mockResolvedValueOnce(fakeWallet)
-
-    const verbsWallet = await provider.toVerbsWallet({
-      client: turnkeyClient,
-      organizationId: 'org_123',
-      signWith: 'key_abc',
+      expect(spyTurnkeyWalletCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client: turnkeyClient,
+          organizationId: 'org_123',
+          signWith: 'key_abc',
+          ethereumAddress: '0x123',
+          chainManager: mockChainManager,
+        }),
+      )
     })
 
-    expect(verbsWallet).toBe(fakeWallet)
+    it('returns the created TurnkeyWallet instance', async () => {
+      const turnkeyClient = {} as unknown as TurnkeySDKClientBase
+      const provider = new TurnkeyHostedWalletProvider(mockChainManager)
+      const fakeWallet = {
+        address: '0xabc',
+      } as unknown as TurnkeyWallet
+      vi.spyOn(TurnkeyWallet, 'create').mockResolvedValueOnce(fakeWallet)
+
+      const verbsWallet = await provider.toVerbsWallet({
+        client: turnkeyClient,
+        organizationId: 'org_123',
+        signWith: 'key_abc',
+      })
+
+      expect(verbsWallet).toBe(fakeWallet)
+    })
+  })
+
+  describe('createSigner', () => {
+    it('should delegate to createSigner utility with correct params', async () => {
+      const provider = new TurnkeyHostedWalletProvider(mockChainManager)
+      const turnkeyClient = {} as unknown as TurnkeySDKClientBase
+
+      const mockSigner = {
+        address: '0xabc',
+        type: 'local',
+      } as unknown as LocalAccount
+
+      const createSignerSpy = vi
+        .spyOn(createSignerUtil, 'createSigner')
+        .mockResolvedValueOnce(mockSigner)
+
+      const params = {
+        client: turnkeyClient,
+        organizationId: 'org_123',
+        signWith: 'key_abc',
+      }
+
+      const signer = await provider.createSigner(params)
+
+      expect(createSignerSpy).toHaveBeenCalledWith(params)
+      expect(signer).toBe(mockSigner)
+    })
   })
 })

--- a/packages/sdk/src/wallet/react/providers/hosted/types/index.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/types/index.ts
@@ -53,7 +53,7 @@ export type PrivyHostedWalletToVerbsWalletOptions = {
  * @description Parameters for converting a hosted wallet to a Verbs wallet
  * @property signWith This can be a wallet account address, private key address, or private key ID.
  * @property ethereumAddress Ethereum address to use for this account, in the case that a private key ID is used to sign.
- * If left undefined, `createAccount` will fetch it from the Turnkey API. We recommend setting this if you're using a passkey
+ * If left undefined, `createSigner` will fetch it from the Turnkey API. We recommend setting this if you're using a passkey
  * client, so that your users are not prompted for a passkey signature just to fetch their address. You may leave this
  * undefined if using an API key client.
  */

--- a/packages/sdk/src/wallet/react/wallets/hosted/dynamic/utils/__tests__/createSigner.spec.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/dynamic/utils/__tests__/createSigner.spec.ts
@@ -1,0 +1,82 @@
+import { isEthereumWallet } from '@dynamic-labs/ethereum'
+import type { DynamicWaasEVMConnector } from '@dynamic-labs/waas-evm'
+import type { Wallet } from '@dynamic-labs/wallet-connector-core'
+import type { LocalAccount, WalletClient } from 'viem'
+import { toAccount } from 'viem/accounts'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getRandomAddress } from '@/test/utils.js'
+import { createSigner } from '@/wallet/react/wallets/hosted/dynamic/utils/createSigner.js'
+
+vi.mock('@dynamic-labs/ethereum', async () => ({
+  isEthereumWallet: vi.fn(),
+}))
+
+vi.mock('viem/accounts', async () => ({
+  // @ts-ignore - importActual returns unknown
+  ...(await vi.importActual('viem/accounts')),
+  toAccount: vi.fn(),
+}))
+
+describe('createSigner (React Dynamic)', () => {
+  const mockAddress = getRandomAddress()
+
+  it('should create a LocalAccount with correct configuration', async () => {
+    const mockWalletClient = {
+      account: {
+        address: mockAddress,
+      },
+      signMessage: vi.fn(),
+      signTransaction: vi.fn(),
+      signTypedData: vi.fn(),
+    } as unknown as WalletClient
+
+    const mockConnector = {
+      signRawMessage: vi.fn(),
+    } as unknown as DynamicWaasEVMConnector
+
+    const mockWallet = {
+      getWalletClient: vi.fn().mockResolvedValue(mockWalletClient),
+      connector: mockConnector,
+    } as unknown as Wallet
+
+    const mockLocalAccount = {
+      address: mockAddress,
+      sign: vi.fn(),
+      signMessage: vi.fn(),
+      signTransaction: vi.fn(),
+      signTypedData: vi.fn(),
+    } as unknown as LocalAccount
+
+    vi.mocked(isEthereumWallet).mockReturnValue(true)
+    vi.mocked(toAccount).mockReturnValue(mockLocalAccount)
+
+    const signer = await createSigner({
+      wallet: mockWallet,
+    })
+
+    expect(isEthereumWallet).toHaveBeenCalledWith(mockWallet)
+    expect(mockWallet.getWalletClient).toHaveBeenCalled()
+    expect(toAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: mockAddress,
+        signMessage: mockWalletClient.signMessage,
+        signTransaction: mockWalletClient.signTransaction,
+        signTypedData: mockWalletClient.signTypedData,
+      }),
+    )
+    expect(signer).toBe(mockLocalAccount)
+  })
+
+  it('should throw error for non-Ethereum wallet', async () => {
+    const mockWallet = {} as unknown as Wallet
+
+    vi.mocked(isEthereumWallet).mockReturnValue(false)
+
+    await expect(
+      createSigner({
+        wallet: mockWallet,
+      }),
+    ).rejects.toThrow('Wallet not connected or not EVM compatible')
+  })
+})

--- a/packages/sdk/src/wallet/react/wallets/hosted/dynamic/utils/createSigner.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/dynamic/utils/createSigner.ts
@@ -1,0 +1,38 @@
+import { isEthereumWallet } from '@dynamic-labs/ethereum'
+import type { DynamicWaasEVMConnector } from '@dynamic-labs/waas-evm'
+import type { LocalAccount } from 'viem'
+import { toAccount } from 'viem/accounts'
+
+import type { DynamicHostedWalletToVerbsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
+
+/**
+ * Create a LocalAccount from a Dynamic wallet
+ * @description Converts the Dynamic wallet into a viem-compatible LocalAccount that can sign
+ * messages and transactions. The returned account uses Dynamic's signing infrastructure
+ * under the hood while providing a standard viem interface.
+ * @param params.dynamicWallet - Dynamic wallet instance
+ * @returns Promise resolving to a LocalAccount configured for signing operations
+ * @throws Error if wallet retrieval fails or signing operations are not supported
+ */
+export async function createSigner(
+  params: DynamicHostedWalletToVerbsWalletOptions,
+): Promise<LocalAccount> {
+  const { wallet } = params
+  if (!isEthereumWallet(wallet)) {
+    throw new Error('Wallet not connected or not EVM compatible')
+  }
+  const walletClient = await wallet.getWalletClient()
+  const connector = wallet.connector as DynamicWaasEVMConnector
+  return toAccount({
+    address: walletClient.account.address,
+    sign: ({ hash }) => {
+      return connector.signRawMessage({
+        accountAddress: walletClient.account.address,
+        message: hash.startsWith('0x') ? hash.slice(2) : hash,
+      })
+    },
+    signMessage: walletClient.signMessage,
+    signTransaction: walletClient.signTransaction,
+    signTypedData: walletClient.signTypedData,
+  })
+}

--- a/packages/sdk/src/wallet/react/wallets/hosted/privy/PrivyWallet.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/privy/PrivyWallet.ts
@@ -1,12 +1,11 @@
 import type { ConnectedWallet } from '@privy-io/react-auth'
-import { toViemAccount } from '@privy-io/react-auth'
-import type { Address, CustomSource, LocalAccount, WalletClient } from 'viem'
+import type { Address, LocalAccount, WalletClient } from 'viem'
 import { createWalletClient, fallback, http } from 'viem'
-import { toAccount } from 'viem/accounts'
 
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import { createSigner } from '@/wallet/react/wallets/hosted/privy/utils/createSigner.js'
 
 /**
  * Privy wallet implementation
@@ -59,7 +58,7 @@ export class PrivyWallet extends Wallet {
    * Initialize the PrivyWallet by creating the signer account
    */
   protected async performInitialization() {
-    this.signer = await this.createAccount()
+    this.signer = await this.createSigner()
     this.address = this.signer.address
   }
 
@@ -71,17 +70,9 @@ export class PrivyWallet extends Wallet {
    * @returns Promise resolving to a LocalAccount configured for signing operations
    * @throws Error if wallet retrieval fails or signing operations are not supported
    */
-  private async createAccount(): Promise<LocalAccount> {
-    const privyViemAccount = await toViemAccount({
-      wallet: this.connectedWallet,
-    })
-    return toAccount({
-      address: privyViemAccount.address,
-      sign: privyViemAccount.sign,
-      signMessage: privyViemAccount.signMessage,
-      signTransaction: privyViemAccount.signTransaction,
-      signTypedData:
-        privyViemAccount.signTypedData as CustomSource['signTypedData'],
+  private async createSigner(): Promise<LocalAccount> {
+    return createSigner({
+      connectedWallet: this.connectedWallet,
     })
   }
 }

--- a/packages/sdk/src/wallet/react/wallets/hosted/privy/utils/__tests__/createSigner.spec.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/privy/utils/__tests__/createSigner.spec.ts
@@ -1,0 +1,66 @@
+import type { ConnectedWallet } from '@privy-io/react-auth'
+import { toViemAccount } from '@privy-io/react-auth'
+import type { LocalAccount } from 'viem'
+import { toAccount } from 'viem/accounts'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getRandomAddress } from '@/test/utils.js'
+import { createSigner } from '@/wallet/react/wallets/hosted/privy/utils/createSigner.js'
+
+vi.mock('@privy-io/react-auth', async () => ({
+  // @ts-ignore - importActual returns unknown
+  ...(await vi.importActual('@privy-io/react-auth')),
+  toViemAccount: vi.fn(),
+}))
+
+vi.mock('viem/accounts', async () => ({
+  // @ts-ignore - importActual returns unknown
+  ...(await vi.importActual('viem/accounts')),
+  toAccount: vi.fn(),
+}))
+
+describe('createSigner', () => {
+  const mockAddress = getRandomAddress()
+
+  it('should create a LocalAccount with correct configuration', async () => {
+    const mockConnectedWallet = {
+      address: mockAddress,
+      walletClientType: 'privy',
+    } as unknown as ConnectedWallet
+
+    const mockPrivyViemAccount = {
+      address: mockAddress,
+      sign: vi.fn(),
+      signMessage: vi.fn(),
+      signTransaction: vi.fn(),
+      signTypedData: vi.fn(),
+    } as unknown as Awaited<ReturnType<typeof toViemAccount>>
+
+    const mockLocalAccount = {
+      address: mockAddress,
+      sign: vi.fn(),
+      signMessage: vi.fn(),
+      signTransaction: vi.fn(),
+      signTypedData: vi.fn(),
+    } as unknown as LocalAccount
+
+    vi.mocked(toViemAccount).mockResolvedValue(mockPrivyViemAccount)
+    vi.mocked(toAccount).mockReturnValue(mockLocalAccount)
+
+    const signer = await createSigner({
+      connectedWallet: mockConnectedWallet,
+    })
+
+    expect(toViemAccount).toHaveBeenCalledWith({
+      wallet: mockConnectedWallet,
+    })
+    expect(toAccount).toHaveBeenCalledWith({
+      address: mockPrivyViemAccount.address,
+      sign: mockPrivyViemAccount.sign,
+      signMessage: mockPrivyViemAccount.signMessage,
+      signTransaction: mockPrivyViemAccount.signTransaction,
+      signTypedData: mockPrivyViemAccount.signTypedData,
+    })
+    expect(signer).toBe(mockLocalAccount)
+  })
+})

--- a/packages/sdk/src/wallet/react/wallets/hosted/privy/utils/createSigner.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/privy/utils/createSigner.ts
@@ -1,0 +1,30 @@
+import { toViemAccount } from '@privy-io/react-auth'
+import type { CustomSource, LocalAccount } from 'viem'
+import { toAccount } from 'viem/accounts'
+
+import type { PrivyHostedWalletToVerbsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
+
+/**
+ * Create a LocalAccount from a Privy wallet
+ * @description Converts the Privy wallet into a viem-compatible LocalAccount that can sign
+ * messages and transactions. The returned account uses Privy's signing infrastructure
+ * under the hood while providing a standard viem interface.
+ * @param params.connectedWallet - Privy connected wallet
+ * @returns Promise resolving to a LocalAccount configured for signing operations
+ * @throws Error if wallet retrieval fails or signing operations are not supported
+ */
+export async function createSigner(
+  params: PrivyHostedWalletToVerbsWalletOptions,
+): Promise<LocalAccount> {
+  const privyViemAccount = await toViemAccount({
+    wallet: params.connectedWallet,
+  })
+  return toAccount({
+    address: privyViemAccount.address,
+    sign: privyViemAccount.sign,
+    signMessage: privyViemAccount.signMessage,
+    signTransaction: privyViemAccount.signTransaction,
+    signTypedData:
+      privyViemAccount.signTypedData as CustomSource['signTypedData'],
+  })
+}

--- a/packages/sdk/src/wallet/react/wallets/hosted/turnkey/utils/__tests__/createSigner.spec.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/turnkey/utils/__tests__/createSigner.spec.ts
@@ -1,0 +1,72 @@
+import type { TurnkeySDKClientBase } from '@turnkey/react-wallet-kit'
+import { createAccount } from '@turnkey/viem'
+import type { LocalAccount } from 'viem'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getRandomAddress } from '@/test/utils.js'
+import { createSigner } from '@/wallet/react/wallets/hosted/turnkey/utils/createSigner.js'
+
+vi.mock('@turnkey/viem', async () => ({
+  createAccount: vi.fn(),
+}))
+
+function createMockTurnkeyClient(): TurnkeySDKClientBase {
+  return {
+    // minimal shape for typing; createAccount uses this via @turnkey/viem
+  } as unknown as TurnkeySDKClientBase
+}
+
+describe('createSigner (React Turnkey)', () => {
+  const mockAddress = getRandomAddress()
+
+  it('should create a LocalAccount with correct configuration', async () => {
+    const mockLocalAccount = {
+      address: mockAddress,
+      signMessage: vi.fn(),
+      sign: vi.fn(),
+      signTransaction: vi.fn(),
+      signTypedData: vi.fn(),
+    } as unknown as LocalAccount
+    vi.mocked(createAccount).mockResolvedValue(mockLocalAccount)
+
+    const client = createMockTurnkeyClient()
+    const signer = await createSigner({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+    })
+
+    expect(createAccount).toHaveBeenCalledWith({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+      ethereumAddress: undefined,
+    })
+    expect(signer).toBe(mockLocalAccount)
+  })
+
+  it('should pass ethereumAddress when provided', async () => {
+    const mockLocalAccount = {
+      address: mockAddress,
+      type: 'local',
+    } as unknown as LocalAccount
+    vi.mocked(createAccount).mockResolvedValue(mockLocalAccount)
+
+    const client = createMockTurnkeyClient()
+    const ethereumAddress = getRandomAddress()
+    const signer = await createSigner({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+      ethereumAddress,
+    })
+
+    expect(createAccount).toHaveBeenCalledWith({
+      client,
+      organizationId: 'org_123',
+      signWith: 'key_abc',
+      ethereumAddress,
+    })
+    expect(signer).toBe(mockLocalAccount)
+  })
+})

--- a/packages/sdk/src/wallet/react/wallets/hosted/turnkey/utils/createSigner.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/turnkey/utils/createSigner.ts
@@ -1,0 +1,29 @@
+import { createAccount } from '@turnkey/viem'
+import type { LocalAccount } from 'viem'
+
+import type { TurnkeyHostedWalletToVerbsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
+
+/**
+ * Create a viem LocalAccount instance backed by Turnkey
+ * @description Wraps the Turnkey SDK's `createAccount` to produce a signing
+ * account compatible with viem. Under the hood, this uses the provided
+ * `client`, `organizationId`, and `signWith` to authenticate signing requests
+ * with Turnkey. If `ethereumAddress` is supplied, it's used directly;
+ * otherwise the SDK fetches it from the Turnkey API.
+ * @param params.client - Turnkey client instance
+ * @param params.organizationId - Turnkey organization ID that owns the signing key
+ * @param params.signWith - Wallet account address, private key address, or private key ID
+ * @param params.ethereumAddress - Ethereum address to use for this account, in the case that a private key ID is used to sign.
+ * @returns Promise resolving to a viem `LocalAccount` with Turnkey as the signer backend
+ */
+export async function createSigner(
+  params: TurnkeyHostedWalletToVerbsWalletOptions,
+): Promise<LocalAccount> {
+  const { client, organizationId, signWith, ethereumAddress } = params
+  return createAccount({
+    client,
+    organizationId,
+    signWith,
+    ethereumAddress,
+  })
+}


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/verbs/issues/159

Exposes a `createSigner` method under `HostedWalletProvider` and `WalletNamespace`. This simplifies the flow for when a signer is needed for a `SmartWallet` instance