### PR TITLE
feat: add support for non-lazy deployments of `DefaultSmartWallet`

### DIFF
--- a/packages/demo/backend/src/app.integration.spec.ts
+++ b/packages/demo/backend/src/app.integration.spec.ts
@@ -18,44 +18,47 @@ vi.mock('./config/verbs.js', () => ({
     wallet: {
       createSmartWallet: vi.fn(() =>
         Promise.resolve({
-          signer: {
-            address: `0x1111111111111111111111111111111111111111`,
-          },
-          address: `0x1111111111111111111111111111111111111112`,
-          getBalance: () =>
-            Promise.resolve([
-              { symbol: 'USDC', balance: 1000000n },
-              { symbol: 'MORPHO', balance: 500000n },
-            ]),
-          lend: {
-            getPosition: vi.fn(
-              ({
-                marketId,
-              }: {
-                marketId: { address: string; chainId: number }
-              }) => {
-                if (
-                  marketId.address ===
-                  '0x38f4f3B6533de0023b9DCd04b02F93d36ad1F9f9'
-                ) {
+          wallet: {
+            signer: {
+              address: `0x1111111111111111111111111111111111111111`,
+            },
+            address: `0x1111111111111111111111111111111111111112`,
+            getBalance: () =>
+              Promise.resolve([
+                { symbol: 'USDC', balance: 1000000n },
+                { symbol: 'MORPHO', balance: 500000n },
+              ]),
+            lend: {
+              getPosition: vi.fn(
+                ({
+                  marketId,
+                }: {
+                  marketId: { address: string; chainId: number }
+                }) => {
+                  if (
+                    marketId.address ===
+                    '0x38f4f3B6533de0023b9DCd04b02F93d36ad1F9f9'
+                  ) {
+                    return Promise.resolve({
+                      balance: 1000000n,
+                      balanceFormatted: '1',
+                      shares: 1000000n,
+                      sharesFormatted: '1',
+                      chainId: 130,
+                    })
+                  }
                   return Promise.resolve({
-                    balance: 1000000n,
-                    balanceFormatted: '1',
-                    shares: 1000000n,
-                    sharesFormatted: '1',
-                    chainId: 130,
+                    balance: 0n,
+                    balanceFormatted: '0',
+                    shares: 0n,
+                    sharesFormatted: '0',
+                    chainId: marketId.chainId,
                   })
-                }
-                return Promise.resolve({
-                  balance: 0n,
-                  balanceFormatted: '0',
-                  shares: 0n,
-                  sharesFormatted: '0',
-                  chainId: marketId.chainId,
-                })
-              },
-            ),
+                },
+              ),
+            },
           },
+          deployments: [{ chainId: 1, receipt: undefined, success: true }],
         }),
       ),
       hostedWalletToVerbsWallet: vi.fn(

--- a/packages/demo/backend/src/services/wallet.spec.ts
+++ b/packages/demo/backend/src/services/wallet.spec.ts
@@ -54,12 +54,15 @@ describe('Wallet Service', () => {
       mockPrivyClient.walletApi.createWallet.mockResolvedValue(mockPrivyWallet)
 
       const mockWallet = {
-        id: 'wallet-123',
-        address: '0x1234567890123456789012345678901234567890',
-        signer: {
+        wallet: {
+          id: 'wallet-123',
           address: '0x1234567890123456789012345678901234567890',
+          signer: {
+            address: '0x1234567890123456789012345678901234567890',
+          },
+          lend: {},
         },
-        lend: {},
+        deployments: [{ chainId: 1, receipt: undefined, success: true }],
       }
 
       mockVerbs.wallet.createSmartWallet.mockResolvedValue(mockWallet)
@@ -113,6 +116,7 @@ describe('Wallet Service', () => {
           type: 'local',
           address: '0x1234567890123456789012345678901234567890',
         },
+        owners: ['0x1234567890123456789012345678901234567890'],
         deploymentOwners: ['0x1234567890123456789012345678901234567890'],
       })
       expect(result).toEqual(mockWallet)
@@ -271,6 +275,7 @@ describe('Wallet Service', () => {
           address: '0x1234567890123456789012345678901234567890',
           type: 'local',
         },
+        owners: ['0x1234567890123456789012345678901234567890'],
         deploymentOwners: ['0x1234567890123456789012345678901234567890'],
       })
       expect(mockWallet.getBalance).toHaveBeenCalled()
@@ -317,6 +322,7 @@ describe('Wallet Service', () => {
           address: mockWallet.address,
           type: 'local',
         },
+        owners: ['0x1234567890123456789012345678901234567890'],
         deploymentOwners: [mockWallet.address],
       })
       expect(mockWallet.getBalance).toHaveBeenCalled()

--- a/packages/demo/backend/src/services/wallet.ts
+++ b/packages/demo/backend/src/services/wallet.ts
@@ -40,7 +40,7 @@ export async function createWallet(): Promise<{
     walletId: privyWallet.id,
     address: getAddress(privyWallet.address),
   })
-  const wallet = await verbs.wallet.createSmartWallet({
+  const { wallet } = await verbs.wallet.createSmartWallet({
     owners: [privySigner.address],
     signer: privySigner,
   })
@@ -85,6 +85,7 @@ export async function getWallet(
   })
   const wallet = await verbs.wallet.getSmartWallet({
     signer: privySigner,
+    owners: [privySigner.address],
     deploymentOwners: [getAddress(privyWallet.address)],
   })
 
@@ -110,6 +111,7 @@ export async function getAllWallets(
         })
         const wallet = await verbs.wallet.getSmartWallet({
           signer: privySigner,
+          owners: [privySigner.address],
           deploymentOwners: [privySigner.address],
         })
         return {

--- a/packages/sdk/src/types/wallet.ts
+++ b/packages/sdk/src/types/wallet.ts
@@ -1,5 +1,6 @@
 import type { Address, LocalAccount } from 'viem'
 
+import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { Signer } from '@/wallet/core/wallets/smart/abstract/types/index.js'
 
 /**
@@ -10,6 +11,7 @@ export type CreateSmartWalletOptions = {
   owners: Signer[]
   signer: LocalAccount
   nonce?: bigint
+  deploymentChainIds?: SupportedChainId[]
 }
 
 /**
@@ -18,8 +20,8 @@ export type CreateSmartWalletOptions = {
  */
 export type GetSmartWalletOptions = {
   signer: LocalAccount
+  owners: Signer[]
   deploymentOwners?: Signer[]
-  signerOwnerIndex?: number
   walletAddress?: Address
   nonce?: bigint
 }

--- a/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
+++ b/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
@@ -6,9 +6,11 @@ import type {
 } from '@/types/wallet.js'
 import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { SmartWalletProvider } from '@/wallet/core/providers/smart/abstract/SmartWalletProvider.js'
+import type { SmartWalletCreationResult } from '@/wallet/core/providers/smart/abstract/types/index.js'
 import type { WalletProvider } from '@/wallet/core/providers/WalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWallet.js'
+
 /**
  * Wallet namespace that provides unified wallet operations
  * @description Provides access to wallet functionality through a single provider interface
@@ -52,18 +54,24 @@ export class WalletNamespace<
 
   /**
    * Create a new smart wallet
-   * @description Creates only a smart wallet using the configured smart wallet provider.
-   * This is useful when you already have a signer and want to create a smart wallet without
-   * creating a hosted wallet. You must provide your own signer and owners array.
+   * @description Creates a smart wallet and attempts to deploy it across all supported chains.
+   * The wallet address is deterministically calculated from owners and nonce. The signer must
+   * be included in the owners array. Deployment failures on individual chains do not prevent
+   * wallet creation - they are reported in the result.
    * @param params - Smart wallet creation parameters
    * @param params.owners - Array of owners for the smart wallet (addresses or WebAuthn public keys)
-   * @param params.signer - Local account used for signing transactions
+   * @param params.signer - Local account used for signing transactions (must be in owners array)
    * @param params.nonce - Optional nonce for smart wallet address generation (defaults to 0)
-   * @returns Promise resolving to the created smart wallet instance
+   * @param params.deploymentChainIds - Optional chain IDs to deploy the wallet to.
+   * If not provided, the wallet will be deployed to all supported chains.
+   * @returns Promise resolving to deployment result containing:
+   * - `wallet`: The created SmartWallet instance
+   * - `deployments`: Array of deployment results with chainId, receipt, success flag, and error
+   * @throws Error if signer is not included in the owners array
    */
   async createSmartWallet(
     params: CreateSmartWalletOptions,
-  ): Promise<SmartWallet> {
+  ): Promise<SmartWalletCreationResult<SmartWallet>> {
     return this.provider.createSmartWallet(params)
   }
 

--- a/packages/sdk/src/wallet/core/namespace/__tests__/WalletNamespace.spec.ts
+++ b/packages/sdk/src/wallet/core/namespace/__tests__/WalletNamespace.spec.ts
@@ -3,6 +3,7 @@ import { getAddress } from 'viem'
 import { unichain } from 'viem/chains'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { createMockLendProvider } from '@/test/MockLendProvider.js'
@@ -14,6 +15,8 @@ import { WalletProvider } from '@/wallet/core/providers/WalletProvider.js'
 import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import { DefaultSmartWallet } from '@/wallet/core/wallets/smart/default/DefaultSmartWallet.js'
 import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
+
+import { SmartWalletDeploymentError } from '../../wallets/smart/error/errors.js'
 
 const mockChainManager = new MockChainManager({
   supportedChains: [unichain.id],
@@ -75,7 +78,7 @@ describe('WalletNamespace', () => {
   })
 
   describe('createSmartWallet', () => {
-    it('should create a smart wallet with provided signer and owners', async () => {
+    it('should create a smart wallet and return deployment result', async () => {
       const hostedWalletProvider = new PrivyHostedWalletProvider(
         mockPrivyClient,
         mockChainManager,
@@ -103,18 +106,96 @@ describe('WalletNamespace', () => {
       const owners = [getRandomAddress(), hostedWallet.address]
       const nonce = BigInt(123)
 
-      const smartWallet = await walletNamespace.createSmartWallet({
+      const result = await walletNamespace.createSmartWallet({
         owners,
         signer: hostedWallet.signer,
         nonce,
       })
 
-      expect(smartWallet).toBeInstanceOf(DefaultSmartWallet)
-      expect(smartWallet.signer).toBe(hostedWallet.signer)
+      expect(result.wallet).toBeInstanceOf(DefaultSmartWallet)
       expect(createSmartWalletSpy).toHaveBeenCalledWith({
         owners,
         signer: hostedWallet.signer,
         nonce,
+      })
+    })
+
+    it('should report deployment successes and failures', async () => {
+      const hostedWalletProvider = new PrivyHostedWalletProvider(
+        mockPrivyClient,
+        mockChainManager,
+      )
+      const smartWalletProvider = new DefaultSmartWalletProvider(
+        mockChainManager,
+        mockLendProvider,
+      )
+      const walletProvider = new WalletProvider(
+        hostedWalletProvider,
+        smartWalletProvider,
+      )
+      const walletNamespace = new WalletNamespace(walletProvider)
+
+      // Create a hosted wallet to use as signer
+      const privyWallet = await mockPrivyClient.walletApi.createWallet({
+        chainType: 'ethereum',
+      })
+      const hostedWallet =
+        await walletProvider.hostedWalletProvider.toVerbsWallet({
+          walletId: privyWallet.id,
+          address: getAddress(privyWallet.address),
+        })
+      const owners = [getRandomAddress(), hostedWallet.address]
+      const nonce = BigInt(456)
+      const deploymentChainIds = [130] as SupportedChainId[]
+
+      // Mock the provider's createSmartWallet to return successes and failures
+      const createSmartWalletSpy = vi.spyOn(walletProvider, 'createSmartWallet')
+      const mockWallet = {} as DefaultSmartWallet
+
+      createSmartWalletSpy.mockResolvedValueOnce({
+        wallet: mockWallet,
+        deployments: [
+          { chainId: 130, receipt: undefined, success: true },
+          {
+            chainId: 8453,
+            error: new SmartWalletDeploymentError(
+              'Deployment failed on chain 8453',
+              8453,
+            ),
+            success: false,
+          },
+        ],
+      })
+
+      const result = await walletNamespace.createSmartWallet({
+        owners,
+        signer: hostedWallet.signer,
+        nonce,
+        deploymentChainIds,
+      })
+
+      // Verify it was called with correct params
+      expect(createSmartWalletSpy).toHaveBeenCalledWith({
+        owners,
+        signer: hostedWallet.signer,
+        nonce,
+        deploymentChainIds,
+      })
+
+      // Verify we have successes and failures
+      expect(result).toEqual({
+        wallet: mockWallet,
+        deployments: [
+          { chainId: 130, receipt: undefined, success: true },
+          {
+            chainId: 8453,
+            error: new SmartWalletDeploymentError(
+              'Deployment failed on chain 8453',
+              8453,
+            ),
+            success: false,
+          },
+        ],
       })
     })
   })
@@ -149,12 +230,11 @@ describe('WalletNamespace', () => {
           address: getAddress(privyWallet.address),
         })
       const deploymentOwners = [hostedWallet.address, getRandomAddress()]
-      const signerOwnerIndex = 0
       const nonce = BigInt(789)
       const params = {
         signer: hostedWallet.signer,
         deploymentOwners,
-        signerOwnerIndex,
+        owners: [hostedWallet.signer.address],
         nonce,
       }
 
@@ -195,6 +275,7 @@ describe('WalletNamespace', () => {
       await expect(
         walletNamespace.getSmartWallet({
           signer: hostedWallet.signer,
+          owners: [hostedWallet.signer.address],
           // Missing both walletAddress and deploymentOwners
         }),
       ).rejects.toThrow(
@@ -304,7 +385,7 @@ describe('WalletNamespace', () => {
 
       // Use the signer to create a smart wallet
       const owners = [signer.address, getRandomAddress()]
-      const smartWallet = await walletNamespace.createSmartWallet({
+      const { wallet: smartWallet } = await walletNamespace.createSmartWallet({
         owners,
         signer,
         nonce: 0n,

--- a/packages/sdk/src/wallet/core/providers/__tests__/WalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/core/providers/__tests__/WalletProvider.spec.ts
@@ -1,6 +1,8 @@
+import type { WaitForUserOperationReceiptReturnType } from 'viem/account-abstraction'
 import { unichain } from 'viem/chains'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { createMockLendProvider } from '@/test/MockLendProvider.js'
@@ -10,6 +12,7 @@ import { DefaultSmartWalletProvider } from '@/wallet/core/providers/smart/defaul
 import { WalletProvider } from '@/wallet/core/providers/WalletProvider.js'
 import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import { DefaultSmartWallet } from '@/wallet/core/wallets/smart/default/DefaultSmartWallet.js'
+import { SmartWalletDeploymentError } from '@/wallet/core/wallets/smart/error/errors.js'
 import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
 import type { PrivyWallet } from '@/wallet/node/wallets/hosted/privy/PrivyWallet.js'
 
@@ -19,12 +22,15 @@ const mockChainManager = new MockChainManager({
 const mockLendProvider = createMockLendProvider()
 
 describe('WalletProvider', () => {
+  let mockPrivyClient: ReturnType<typeof createMockPrivyClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPrivyClient = createMockPrivyClient('test-app-id', 'test-app-secret')
+  })
+
   describe('createSmartWallet', () => {
-    it('should create a smart wallet with provided signer and owners', async () => {
-      const mockPrivyClient = createMockPrivyClient(
-        'test-app-id',
-        'test-app-secret',
-      )
+    it('should create a smart wallet and return deployment result', async () => {
       const hostedWalletProvider = new PrivyHostedWalletProvider(
         mockPrivyClient,
         mockChainManager,
@@ -33,7 +39,6 @@ describe('WalletProvider', () => {
         mockChainManager,
         mockLendProvider,
       )
-      const createWalletSpy = vi.spyOn(smartWalletProvider, 'createWallet')
       const walletProvider = new WalletProvider(
         hostedWalletProvider,
         smartWalletProvider,
@@ -48,28 +53,175 @@ describe('WalletProvider', () => {
       const owners = [getRandomAddress(), hostedWallet.address]
       const nonce = BigInt(123)
 
-      const smartWallet = await walletProvider.createSmartWallet({
+      const mockWallet = {} as DefaultSmartWallet
+      const mockDeploymentResult = {
+        wallet: mockWallet,
+        deployments: [
+          {
+            chainId: unichain.id as SupportedChainId,
+            receipt: undefined,
+            success: true,
+          },
+        ],
+      }
+
+      const createWalletSpy = vi
+        .spyOn(smartWalletProvider, 'createWallet')
+        .mockResolvedValue(mockDeploymentResult)
+
+      const result = await walletProvider.createSmartWallet({
         owners,
         signer,
         nonce,
       })
 
-      expect(smartWallet).toBeInstanceOf(DefaultSmartWallet)
-      expect(smartWallet.signer).toBe(signer)
       expect(createWalletSpy).toHaveBeenCalledWith({
         owners,
         signer,
         nonce,
       })
+      expect(result).toEqual(mockDeploymentResult)
+    })
+
+    it('should pass through deployment successes and failures', async () => {
+      const hostedWalletProvider = new PrivyHostedWalletProvider(
+        mockPrivyClient,
+        mockChainManager,
+      )
+      const smartWalletProvider = new DefaultSmartWalletProvider(
+        mockChainManager,
+        mockLendProvider,
+      )
+      const walletProvider = new WalletProvider(
+        hostedWalletProvider,
+        smartWalletProvider,
+      )
+
+      const hostedWallet = (await hostedWalletProvider.toVerbsWallet({
+        walletId: 'mock-wallet-1',
+        address: getRandomAddress(),
+      })) as PrivyWallet
+      const signer = hostedWallet.signer
+      const owners = [getRandomAddress(), hostedWallet.address]
+
+      const mockWallet = {} as DefaultSmartWallet
+      const mockReceipt = {
+        success: true,
+      } as unknown as WaitForUserOperationReceiptReturnType
+      const mockDeploymentResult = {
+        wallet: mockWallet,
+        deployments: [
+          {
+            chainId: unichain.id as SupportedChainId,
+            receipt: mockReceipt,
+            success: true,
+          },
+          {
+            chainId: 8453 as SupportedChainId,
+            receipt: mockReceipt,
+            success: false,
+            error: new SmartWalletDeploymentError('Deployment failed', 8453),
+          },
+        ],
+      }
+
+      vi.spyOn(smartWalletProvider, 'createWallet').mockResolvedValue(
+        mockDeploymentResult,
+      )
+
+      const result = await walletProvider.createSmartWallet({
+        owners,
+        signer,
+      })
+
+      expect(result).toEqual(mockDeploymentResult)
+    })
+
+    it('should forward deploymentChainIds parameter', async () => {
+      const hostedWalletProvider = new PrivyHostedWalletProvider(
+        mockPrivyClient,
+        mockChainManager,
+      )
+      const smartWalletProvider = new DefaultSmartWalletProvider(
+        mockChainManager,
+        mockLendProvider,
+      )
+      const walletProvider = new WalletProvider(
+        hostedWalletProvider,
+        smartWalletProvider,
+      )
+
+      const hostedWallet = (await hostedWalletProvider.toVerbsWallet({
+        walletId: 'mock-wallet-1',
+        address: getRandomAddress(),
+      })) as PrivyWallet
+      const signer = hostedWallet.signer
+      const owners = [getRandomAddress(), hostedWallet.address]
+      const deploymentChainIds: SupportedChainId[] = [8453]
+
+      const mockWallet = {} as DefaultSmartWallet
+      const mockDeploymentResult = {
+        wallet: mockWallet,
+        deployments: [
+          {
+            chainId: 8453 as SupportedChainId,
+            receipt: undefined,
+            success: true,
+          },
+        ],
+      }
+
+      const createWalletSpy = vi
+        .spyOn(smartWalletProvider, 'createWallet')
+        .mockResolvedValue(mockDeploymentResult)
+
+      const result = await walletProvider.createSmartWallet({
+        owners,
+        signer,
+        deploymentChainIds,
+      })
+
+      expect(createWalletSpy).toHaveBeenCalledWith({
+        owners,
+        signer,
+        deploymentChainIds,
+      })
+      expect(result).toEqual(mockDeploymentResult)
+    })
+
+    it('should throw error if signer is not in owners array', async () => {
+      const hostedWalletProvider = new PrivyHostedWalletProvider(
+        mockPrivyClient,
+        mockChainManager,
+      )
+      const smartWalletProvider = new DefaultSmartWalletProvider(
+        mockChainManager,
+        mockLendProvider,
+      )
+      const walletProvider = new WalletProvider(
+        hostedWalletProvider,
+        smartWalletProvider,
+      )
+
+      const hostedWallet = (await hostedWalletProvider.toVerbsWallet({
+        walletId: 'mock-wallet-1',
+        address: getRandomAddress(),
+      })) as PrivyWallet
+      const signer = hostedWallet.signer
+      // Signer is NOT in the owners array
+      const owners = [getRandomAddress(), getRandomAddress()]
+
+      await expect(
+        walletProvider.createSmartWallet({
+          owners,
+          signer,
+        }),
+      ).rejects.toThrow('Signer must be in the owners array')
     })
   })
 
   describe('getSmartWallet', () => {
     it('should get a smart wallet with provided signer', async () => {
-      const mockPrivyClient = createMockPrivyClient(
-        'test-app-id',
-        'test-app-secret',
-      )
       const hostedWalletProvider = new PrivyHostedWalletProvider(
         mockPrivyClient,
         mockChainManager,
@@ -94,13 +246,12 @@ describe('WalletProvider', () => {
       })) as PrivyWallet
       const signer = hostedWallet.signer
       const deploymentOwners = [hostedWallet.address, getRandomAddress()]
-      const signerOwnerIndex = 0
       const nonce = BigInt(789)
 
       const smartWallet = await walletProvider.getSmartWallet({
         signer,
         deploymentOwners,
-        signerOwnerIndex,
+        owners: [signer.address],
         nonce,
       })
 
@@ -112,15 +263,11 @@ describe('WalletProvider', () => {
       expect(getWalletSpy).toHaveBeenCalledWith({
         walletAddress: mockWalletAddress,
         signer,
-        ownerIndex: signerOwnerIndex,
+        owners: [signer.address],
       })
     })
 
     it('should throw error when getting smart wallet without required parameters', async () => {
-      const mockPrivyClient = createMockPrivyClient(
-        'test-app-id',
-        'test-app-secret',
-      )
       const hostedWalletProvider = new PrivyHostedWalletProvider(
         mockPrivyClient,
         mockChainManager,
@@ -143,6 +290,7 @@ describe('WalletProvider', () => {
       await expect(
         walletProvider.getSmartWallet({
           signer,
+          owners: [signer.address],
           // Missing both walletAddress and deploymentOwners
         }),
       ).rejects.toThrow(
@@ -153,10 +301,6 @@ describe('WalletProvider', () => {
 
   describe('hostedWalletToVerbsWallet', () => {
     it('should convert a hosted wallet to a Verbs wallet', async () => {
-      const mockPrivyClient = createMockPrivyClient(
-        'test-app-id',
-        'test-app-secret',
-      )
       const hostedWalletProvider = new PrivyHostedWalletProvider(
         mockPrivyClient,
         mockChainManager,

--- a/packages/sdk/src/wallet/core/providers/smart/abstract/types/index.ts
+++ b/packages/sdk/src/wallet/core/providers/smart/abstract/types/index.ts
@@ -1,0 +1,17 @@
+import type { WaitForUserOperationReceiptReturnType } from 'viem/account-abstraction'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWallet.js'
+import type { SmartWalletDeploymentError } from '@/wallet/core/wallets/smart/error/errors.js'
+
+interface SmartWalletDeployment {
+  chainId: SupportedChainId
+  success: boolean
+  receipt?: WaitForUserOperationReceiptReturnType
+  error?: SmartWalletDeploymentError
+}
+
+export type SmartWalletCreationResult<TWallet extends SmartWallet> = {
+  wallet: TWallet
+  deployments: SmartWalletDeployment[]
+}

--- a/packages/sdk/src/wallet/core/wallets/smart/default/__mocks__/DefaultSmartWallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/default/__mocks__/DefaultSmartWallet.ts
@@ -1,0 +1,180 @@
+import type { Address, Hex, LocalAccount, WalletClient } from 'viem'
+import type { WaitForUserOperationReceiptReturnType } from 'viem/account-abstraction'
+import { vi } from 'vitest'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+import type { Asset } from '@/types/asset.js'
+import type { TransactionData } from '@/types/lend/index.js'
+import type { DefaultSmartWallet } from '@/wallet/core/wallets/smart/default/DefaultSmartWallet.js'
+
+export type CreateDefaultSmartWalletMockOptions = {
+  /** Mock wallet address */
+  address?: Address
+  /** Mock signer */
+  signer?: LocalAccount
+  /** Custom implementation for deploy */
+  deployImpl?: (chainId: SupportedChainId) => Promise<{
+    chainId: SupportedChainId
+    success: boolean
+    receipt?: WaitForUserOperationReceiptReturnType
+  }>
+  /** Custom implementation for addSigner */
+  addSignerImpl?: (
+    owner: Address | { type: 'webAuthn'; publicKey: Hex },
+    chainId: SupportedChainId,
+  ) => Promise<number>
+  /** Custom implementation for findSignerIndex */
+  findSignerIndexImpl?: (
+    signer: Address | { type: 'webAuthn'; publicKey: Hex },
+    chainId: SupportedChainId,
+  ) => Promise<number>
+  /** Custom implementation for removeSigner */
+  removeSignerImpl?: (
+    signer: Address | { type: 'webAuthn'; publicKey: Hex },
+    chainId: SupportedChainId,
+    signerIndex?: number,
+  ) => Promise<WaitForUserOperationReceiptReturnType>
+  /** Custom implementation for send */
+  sendImpl?: (
+    transactionData: TransactionData,
+    chainId: SupportedChainId,
+  ) => Promise<WaitForUserOperationReceiptReturnType>
+  /** Custom implementation for sendBatch */
+  sendBatchImpl?: (
+    transactionData: TransactionData[],
+    chainId: SupportedChainId,
+  ) => Promise<WaitForUserOperationReceiptReturnType>
+  /** Optional custom walletClient implementation */
+  walletClientImpl?: (chainId: SupportedChainId) => Promise<WalletClient>
+  /** Optional custom sendTokens implementation */
+  sendTokensImpl?: (
+    amount: number,
+    asset: Asset,
+    chainId: SupportedChainId,
+    recipientAddress: Address,
+  ) => Promise<TransactionData>
+}
+
+/**
+ * Create a mock DefaultSmartWallet instance
+ * @description Returns an object typed as `DefaultSmartWallet` with configurable
+ * implementations for all methods. Each method is wrapped with `vi.fn()` for spying.
+ */
+export function createMock(
+  options: CreateDefaultSmartWalletMockOptions = {},
+): DefaultSmartWallet {
+  const defaultReceipt = {
+    success: true,
+  } as unknown as WaitForUserOperationReceiptReturnType
+
+  const address: Address = (options.address ??
+    '0x0000000000000000000000000000000000000000') as Address
+  const signer: LocalAccount =
+    options.signer ?? ({ address, type: 'local' } as unknown as LocalAccount)
+
+  const deploy = vi.fn(
+    async (
+      chainId: SupportedChainId,
+    ): Promise<{
+      chainId: SupportedChainId
+      success: boolean
+      receipt?: WaitForUserOperationReceiptReturnType
+    }> => {
+      if (options.deployImpl) return options.deployImpl(chainId)
+      return { chainId, success: true, receipt: undefined }
+    },
+  )
+
+  const addSigner = vi.fn(
+    async (
+      owner: Address | { type: 'webAuthn'; publicKey: Hex },
+      chainId: SupportedChainId,
+    ): Promise<number> => {
+      if (options.addSignerImpl) return options.addSignerImpl(owner, chainId)
+      return 0
+    },
+  )
+
+  const findSignerIndex = vi.fn(
+    async (
+      signer: Address | { type: 'webAuthn'; publicKey: Hex },
+      chainId: SupportedChainId,
+    ): Promise<number> => {
+      if (options.findSignerIndexImpl)
+        return options.findSignerIndexImpl(signer, chainId)
+      return -1
+    },
+  )
+
+  const removeSigner = vi.fn(
+    async (
+      signer: Address | { type: 'webAuthn'; publicKey: Hex },
+      chainId: SupportedChainId,
+      signerIndex?: number,
+    ): Promise<WaitForUserOperationReceiptReturnType> => {
+      if (options.removeSignerImpl)
+        return options.removeSignerImpl(signer, chainId, signerIndex)
+      return defaultReceipt
+    },
+  )
+
+  const send = vi.fn(
+    async (
+      transactionData: TransactionData,
+      chainId: SupportedChainId,
+    ): Promise<WaitForUserOperationReceiptReturnType> => {
+      if (options.sendImpl) return options.sendImpl(transactionData, chainId)
+      return defaultReceipt
+    },
+  )
+
+  const sendBatch = vi.fn(
+    async (
+      transactionData: TransactionData[],
+      chainId: SupportedChainId,
+    ): Promise<WaitForUserOperationReceiptReturnType> => {
+      if (options.sendBatchImpl)
+        return options.sendBatchImpl(transactionData, chainId)
+      return defaultReceipt
+    },
+  )
+
+  const walletClient = vi.fn(
+    async (chainId: SupportedChainId): Promise<WalletClient> => {
+      if (options.walletClientImpl) return options.walletClientImpl(chainId)
+      throw new Error('walletClient not implemented in DefaultSmartWallet mock')
+    },
+  )
+
+  const sendTokens = vi.fn(
+    async (
+      amount: number,
+      asset: Asset,
+      chainId: SupportedChainId,
+      recipientAddress: Address,
+    ): Promise<TransactionData> => {
+      if (options.sendTokensImpl)
+        return options.sendTokensImpl(amount, asset, chainId, recipientAddress)
+      throw new Error('sendTokens not implemented in DefaultSmartWallet mock')
+    },
+  )
+
+  const mock = {
+    get address() {
+      return address
+    },
+    get signer() {
+      return signer
+    },
+    deploy,
+    addSigner,
+    findSignerIndex,
+    removeSigner,
+    walletClient,
+    send,
+    sendBatch,
+    sendTokens,
+  } as unknown as DefaultSmartWallet
+
+  return mock
+}

--- a/packages/sdk/src/wallet/core/wallets/smart/default/types/index.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/default/types/index.ts
@@ -1,0 +1,4 @@
+import type { Address, LocalAccount, OneOf } from 'viem'
+import type { WebAuthnAccount } from 'viem/account-abstraction'
+
+export type Owners = Array<Address | OneOf<LocalAccount | WebAuthnAccount>>

--- a/packages/sdk/src/wallet/core/wallets/smart/default/utils/__tests__/findSignerIndex.spec.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/default/utils/__tests__/findSignerIndex.spec.ts
@@ -1,0 +1,80 @@
+import type { Address, Hex, LocalAccount } from 'viem'
+import { pad } from 'viem'
+import type { WebAuthnAccount } from 'viem/account-abstraction'
+import { describe, expect, it } from 'vitest'
+
+import { getRandomAddress } from '@/test/utils.js'
+import { findSignerIndex } from '@/wallet/core/wallets/smart/default/utils/findSignerIndex.js'
+
+describe('findSignerIndex', () => {
+  const mockAddress1 = getRandomAddress()
+  const mockAddress2 = getRandomAddress()
+  const mockPublicKey1 = pad('0xaabb', { size: 32 }) as Hex
+
+  it('should find LocalAccount address in owners array with EOA addresses', () => {
+    const owners = [mockAddress1, mockAddress2]
+    const signer = {
+      address: mockAddress1,
+      type: 'local',
+    } as unknown as LocalAccount
+
+    const index = findSignerIndex(owners, signer)
+
+    expect(index).toBe(0)
+  })
+
+  it('should find LocalAccount in owners array by matching address', () => {
+    const owners = [mockAddress1, mockAddress2]
+    const signer = {
+      address: mockAddress2,
+      type: 'local',
+    } as unknown as LocalAccount
+
+    const index = findSignerIndex(owners, signer)
+
+    expect(index).toBe(1)
+  })
+
+  it('should return -1 when LocalAccount address is not found in owners', () => {
+    const owners = [mockAddress1, mockAddress2]
+    const signer = {
+      address: '0x3333333333333333333333333333333333333333' as Address,
+      type: 'local',
+    } as unknown as LocalAccount
+
+    const index = findSignerIndex(owners, signer)
+
+    expect(index).toBe(-1)
+  })
+
+  it('should ignore WebAuthn accounts in owners array and only match addresses', () => {
+    const webAuthnAccount: WebAuthnAccount = {
+      type: 'webAuthn',
+      publicKey: mockPublicKey1,
+      address: mockAddress2,
+    } as unknown as WebAuthnAccount
+
+    const owners = [mockAddress1, webAuthnAccount]
+    const signer = {
+      address: mockAddress2,
+      type: 'local',
+    } as unknown as LocalAccount
+
+    // Should return -1 because we only match EOA addresses, not WebAuthn accounts
+    const index = findSignerIndex(owners, signer)
+
+    expect(index).toBe(-1)
+  })
+
+  it('should throw error when signer is not a LocalAccount', () => {
+    const owners = [mockAddress1, mockAddress2]
+    const notLocalAccount = {
+      address: mockAddress1,
+      type: 'webAuthn',
+    } as unknown as LocalAccount
+
+    expect(() => findSignerIndex(owners, notLocalAccount)).toThrow(
+      'Signer is not a LocalAccount',
+    )
+  })
+})

--- a/packages/sdk/src/wallet/core/wallets/smart/default/utils/findSignerIndex.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/default/utils/findSignerIndex.ts
@@ -1,0 +1,30 @@
+import { getAddress, type LocalAccount } from 'viem'
+
+import type { Signer } from '@/wallet/core/wallets/smart/abstract/types/index.js'
+
+/**
+ * Find the index of a signer in the owners array
+ * @description Searches through the owners array to find the index where the signer matches.
+ * We only support signer type of LocalAccount for now.
+ * @param owners - Array of wallet owners (addresses, LocalAccounts, or WebAuthn accounts)
+ * @param signer - The signer to find in the owners array
+ * @returns The index of the signer in the owners array
+ */
+export function findSignerIndex(
+  owners: Signer[],
+  signer: LocalAccount,
+): number {
+  if (signer.type !== 'local') {
+    throw new Error('Signer is not a LocalAccount')
+  }
+
+  return owners.findIndex((owner) => {
+    // we only support signer type of LocalAccount for now
+    if (typeof owner === 'string') {
+      // EOA address comparison
+      return getAddress(owner) === getAddress(signer.address)
+    }
+
+    return false
+  })
+}

--- a/packages/sdk/src/wallet/core/wallets/smart/error/errors.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/error/errors.ts
@@ -1,0 +1,18 @@
+import type { WaitForUserOperationReceiptReturnType } from 'viem/account-abstraction'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+
+export class SmartWalletDeploymentError extends Error {
+  chainId: SupportedChainId
+  receipt?: WaitForUserOperationReceiptReturnType
+  constructor(
+    message: string,
+    chainId: SupportedChainId,
+    receipt?: WaitForUserOperationReceiptReturnType,
+  ) {
+    super(message)
+    this.name = 'SmartWalletDeploymentError'
+    this.chainId = chainId
+    this.receipt = receipt
+  }
+}


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/verbs/issues/98

### Motivation

Previously, smart wallets only supported lazy deployment via ERC-4337 initCode, which meant deployments happened implicitly during the first transaction. This worked for simple use cases, but developers need more control over when and where wallets are deployed, especially for multi-chain scenarios.

### Changes
- Added `deploy()` method to `DefaultSmartWallet` for explicit wallet deployment
- ` createSmartWallet()` now calls `deploy()` and returns `SmartWalletDeploymentResult` containing:
  - `wallet`: The created `SmartWallet` instance
  - `deploymentSuccesses`: Array of successful deployments per chain
  - `deploymentFailures`: Array of failed deployments with error details
- Added optional `deploymentChainIds` parameter to control which chains to deploy to (pass `[]` to have lazy deployment)