### PR TITLE
feat: add send and sendBatch method to all wallets

### DIFF
--- a/packages/demo/backend/src/services/lend.spec.ts
+++ b/packages/demo/backend/src/services/lend.spec.ts
@@ -148,7 +148,8 @@ describe('Lend Service', () => {
         isUserWallet: false,
       })
 
-      expect(result.hash).toBe('0xtxhash')
+      expect(result.transactionHashes).toBeUndefined()
+      expect(result.userOpHash).toBe('0xuserophash')
       expect(mockWallet.lend.closePosition).toHaveBeenCalledWith({
         amount,
         asset: expect.objectContaining({

--- a/packages/demo/backend/src/types/lend.ts
+++ b/packages/demo/backend/src/types/lend.ts
@@ -37,9 +37,9 @@ export interface PositionParams {
  * Position operation response
  */
 export interface PositionResponse {
-  hash: string
+  transactionHashes?: string[]
   userOpHash?: string
-  blockExplorerUrl: string
+  blockExplorerUrls: string[]
   amount: number
   tokenAddress: Address
   marketId: LendMarketId

--- a/packages/demo/frontend/src/components/Terminal.tsx
+++ b/packages/demo/frontend/src/components/Terminal.tsx
@@ -1085,15 +1085,15 @@ User ID: ${result.userId}`,
 
       console.log(
         `[FRONTEND] ${operationType === 'close' ? 'Withdrawal' : 'Deposit'} successful:`,
-        result.transaction.hash,
+        result.transaction.blockExplorerUrls,
       )
 
       const successLine: TerminalLine = {
         id: `lend-success-${Date.now()}`,
         type: 'success',
         content: operationType === 'close'
-          ? `✅ Successfully withdrew ${amount} ${amountUnit}!\n\nMarket:  ${promptData.selectedMarket.name}\nAmount: ${amount} ${amountUnit}\nTx:     ${result.transaction.blockExplorerUrl}/${result.transaction.hash || 'pending'}`
-          : `✅ Successfully lent ${amount} ${amountUnit} to ${promptData.selectedMarket.name}!\n\nMarket:  ${promptData.selectedMarket.name}\nAmount: ${amount} ${amountUnit}\nTx:     ${result.transaction.blockExplorerUrl}/${result.transaction.hash || 'pending'}`,
+          ? `✅ Successfully withdrew ${amount} ${amountUnit}!\n\nMarket:  ${promptData.selectedMarket.name}\nAmount: ${amount} ${amountUnit}\nTx:     ${result.transaction.blockExplorerUrls.join('\n') || 'pending'}`
+          : `✅ Successfully lent ${amount} ${amountUnit} to ${promptData.selectedMarket.name}!\n\nMarket:  ${promptData.selectedMarket.name}\nAmount: ${amount} ${amountUnit}\nTx:     ${result.transaction.blockExplorerUrls.join('\n') || 'pending'}`,
         timestamp: new Date(),
       }
       setLines((prev) => [...prev.slice(0, -1), successLine])

--- a/packages/demo/frontend/src/types/api.ts
+++ b/packages/demo/frontend/src/types/api.ts
@@ -49,9 +49,9 @@ export interface PositionResponse {
 }
 
 export interface TransactionResponse {
-  hash: string
+  transactionHashes?: string[]
   userOpHash?: string
-  blockExplorerUrl: string
+  blockExplorerUrls: string[]
   amount: number
   tokenAddress: string
   marketId: {

--- a/packages/sdk/src/actions.ts
+++ b/packages/sdk/src/actions.ts
@@ -141,7 +141,7 @@ export class Actions<
       )
     }
     this.hostedWalletProvider = factory.create(
-      { chainManager: this.chainManager },
+      { chainManager: this.chainManager, lendProvider: this.lendProvider },
       options,
     )
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,7 @@ export type {
   ApyBreakdown,
   Asset,
   BaseLendConfig,
+  EOATransactionReceipt,
   LendConfig,
   LendMarket,
   LendMarketConfig,
@@ -26,6 +27,7 @@ export type {
   MorphoLendConfig,
   TokenBalance,
   TransactionData,
+  UserOperationTransactionReceipt,
   WalletConfig,
 } from '@/types/index.js'
 export { getAssetAddress, isAssetSupportedOnChain } from '@/utils/assets.js'

--- a/packages/sdk/src/lend/namespaces/WalletLendNamespace.ts
+++ b/packages/sdk/src/lend/namespaces/WalletLendNamespace.ts
@@ -8,7 +8,6 @@ import type {
   LendTransactionReceipt,
 } from '@/types/lend/index.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
-import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWallet.js'
 
 /**
  * Wallet Lend Namespace
@@ -54,12 +53,6 @@ export class WalletLendNamespace<
       throw new Error('No transaction data returned from lend provider')
     }
 
-    if (!this.isSmartWallet(this.wallet)) {
-      throw new Error(
-        'Transaction execution is only supported for SmartWallet instances',
-      )
-    }
-
     if (transactionData.approval && transactionData.openPosition) {
       return await this.wallet.sendBatch(
         [transactionData.approval, transactionData.openPosition],
@@ -70,15 +63,10 @@ export class WalletLendNamespace<
     if (!transactionData.openPosition) {
       throw new Error('No openPosition transaction data returned')
     }
-    const userOperationReceipt = await this.wallet.send(
+    return await this.wallet.send(
       transactionData.openPosition,
       params.marketId.chainId,
     )
-
-    return {
-      receipt: userOperationReceipt.receipt,
-      userOpHash: userOperationReceipt.userOpHash,
-    }
   }
 
   /**
@@ -116,36 +104,13 @@ export class WalletLendNamespace<
       )
     }
 
-    if (!this.isSmartWallet(this.wallet)) {
-      throw new Error(
-        'Transaction execution is only supported for SmartWallet instances',
-      )
-    }
-
     if (!transactionData.closePosition) {
       throw new Error('No closePosition transaction data returned')
     }
 
-    const userOperationReceipt = await this.wallet.send(
+    return await this.wallet.send(
       transactionData.closePosition,
       params.marketId.chainId,
-    )
-
-    return {
-      receipt: userOperationReceipt.receipt,
-      userOpHash: userOperationReceipt.userOpHash,
-    }
-  }
-
-  /**
-   * Type guard to check if wallet is a SmartWallet
-   */
-  private isSmartWallet(wallet: Wallet): wallet is SmartWallet {
-    return (
-      'send' in wallet &&
-      typeof wallet.send === 'function' &&
-      'sendBatch' in wallet &&
-      typeof wallet.sendBatch === 'function'
     )
   }
 }

--- a/packages/sdk/src/lend/namespaces/__tests__/WalletLendNamespace.spec.ts
+++ b/packages/sdk/src/lend/namespaces/__tests__/WalletLendNamespace.spec.ts
@@ -12,7 +12,6 @@ describe('WalletLendNamespace', () => {
   const mockWalletAddress = getRandomAddress()
   let mockProvider: LendProvider
   let mockWallet: SmartWallet
-  let mockRegularWallet: any
 
   beforeEach(() => {
     mockProvider = createMockLendProvider()
@@ -30,13 +29,6 @@ describe('WalletLendNamespace', () => {
           userOpHash: '0xmockbatchhash',
         }) as unknown as WaitForUserOperationReceiptReturnType,
     }) as unknown as SmartWallet
-
-    // Create a mock regular wallet without SmartWallet methods
-    mockRegularWallet = {
-      address: mockWalletAddress,
-      send: undefined,
-      sendBatch: undefined,
-    }
   })
 
   it('should create an instance with a lend provider and wallet', () => {
@@ -173,34 +165,6 @@ describe('WalletLendNamespace', () => {
         receipt: { success: true },
         userOpHash: '0xmockhash',
       })
-    })
-
-    it('should throw error for non-SmartWallet', async () => {
-      const namespace = new WalletLendNamespace(mockProvider, mockRegularWallet)
-      const closeParams = {
-        amount: 100,
-        marketId: { address: getRandomAddress(), chainId: 130 as const },
-      }
-
-      const mockTransaction = {
-        amount: 100n,
-        asset: getRandomAddress(),
-        marketId: closeParams.marketId.address,
-        apy: 0.05,
-        transactionData: {
-          closePosition: {
-            to: closeParams.marketId.address,
-            value: 0n,
-            data: '0x' as const,
-          },
-        },
-      }
-
-      vi.mocked(mockProvider.closePosition).mockResolvedValue(mockTransaction)
-
-      await expect(namespace.closePosition(closeParams)).rejects.toThrow(
-        'Transaction execution is only supported for SmartWallet instances',
-      )
     })
   })
 

--- a/packages/sdk/src/services/ChainManager.ts
+++ b/packages/sdk/src/services/ChainManager.ts
@@ -135,6 +135,19 @@ export class ChainManager {
   }
 
   /**
+   * Get transport for a specific chain with fallback support
+   * @param chainId - The chain ID to retrieve the transport for
+   * @returns Transport configured with fallback RPC URLs or default http transport
+   * @throws Error if no chain config is found for the chain ID
+   */
+  getTransportForChain(chainId: (typeof SUPPORTED_CHAIN_IDS)[number]) {
+    const rpcUrls = this.getRpcUrls(chainId)
+    return rpcUrls?.length
+      ? fallback(rpcUrls.map((rpcUrl) => http(rpcUrl)))
+      : http()
+  }
+
+  /**
    * Create public clients for all configured chains
    * @param chains - Array of chain configurations
    * @returns Map of chain IDs to their corresponding public clients
@@ -160,9 +173,7 @@ export class ChainManager {
       }
       const client = createPublicClient({
         chain,
-        transport: chainConfig.rpcUrls?.length
-          ? fallback(chainConfig.rpcUrls.map((rpcUrl) => http(rpcUrl)))
-          : http(),
+        transport: this.getTransportForChain(chainConfig.chainId),
       })
 
       clients.set(chainConfig.chainId, client)

--- a/packages/sdk/src/test/MockChainManager.ts
+++ b/packages/sdk/src/test/MockChainManager.ts
@@ -87,6 +87,12 @@ export class MockChainManager {
     return this.getChain(chainId).rpcUrls.default.http as string[]
   }
 
+  getTransportForChain(_chainId: (typeof SUPPORTED_CHAIN_IDS)[number]) {
+    // Mock implementation returns a simple http transport
+    // In tests, the actual transport behavior is typically mocked at a higher level
+    return {} as unknown
+  }
+
   private createMockBundlerClients(): Map<SupportedChainId, BundlerClient> {
     const clients = new Map<SupportedChainId, BundlerClient>()
 

--- a/packages/sdk/src/types/lend/base.ts
+++ b/packages/sdk/src/types/lend/base.ts
@@ -1,7 +1,11 @@
-import type { Address, Hash, Hex, TransactionReceipt } from 'viem'
+import type { Address, Hex } from 'viem'
 
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { Asset } from '@/types/asset.js'
+import type {
+  BatchTransactionReturnType,
+  TransactionReturnType,
+} from '@/wallet/core/wallets/abstract/types/index.js'
 
 export { LendProvider } from '@/lend/core/LendProvider.js'
 export { ActionsLendNamespace } from '@/lend/namespaces/ActionsLendNamespace.js'
@@ -94,10 +98,9 @@ export interface LendTransaction {
 /**
  * Lending transaction receipt
  */
-export interface LendTransactionReceipt {
-  receipt: TransactionReceipt<bigint, number, 'success' | 'reverted'>
-  userOpHash?: Hash
-}
+export type LendTransactionReceipt =
+  | TransactionReturnType
+  | BatchTransactionReturnType
 
 /**
  * Lending market information

--- a/packages/sdk/src/types/wallet.ts
+++ b/packages/sdk/src/types/wallet.ts
@@ -3,6 +3,7 @@ import type { Address, LocalAccount } from 'viem'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { Signer } from '@/wallet/core/wallets/smart/abstract/types/index.js'
 
+export * from '@/wallet/core/wallets/abstract/types/index.js'
 /**
  * Options for creating a smart wallet
  * @description Parameters for creating a new smart wallet with specified owners and signer

--- a/packages/sdk/src/wallet/core/providers/hosted/abstract/HostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/core/providers/hosted/abstract/HostedWalletProvider.ts
@@ -1,6 +1,7 @@
 import type { LocalAccount } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 
 /**
@@ -14,9 +15,14 @@ export abstract class HostedWalletProvider<
   TOptionsMap extends Record<TType, unknown>,
 > {
   protected chainManager: ChainManager
+  protected lendProvider?: LendProvider<LendConfig>
 
-  protected constructor(chainManager: ChainManager) {
+  protected constructor(
+    chainManager: ChainManager,
+    lendProvider?: LendProvider<LendConfig>,
+  ) {
     this.chainManager = chainManager
+    this.lendProvider = lendProvider
   }
   /**
    * Convert a hosted wallet to an Actions wallet

--- a/packages/sdk/src/wallet/core/providers/hosted/types/index.ts
+++ b/packages/sdk/src/wallet/core/providers/hosted/types/index.ts
@@ -1,4 +1,5 @@
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 
 /**
@@ -9,6 +10,7 @@ import type { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstra
  */
 export interface HostedProviderDeps {
   chainManager: ChainManager
+  lendProvider?: LendProvider<LendConfig>
 }
 
 /**

--- a/packages/sdk/src/wallet/core/wallets/abstract/__mocks__/TestWallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/abstract/__mocks__/TestWallet.ts
@@ -1,0 +1,40 @@
+import type { Address, LocalAccount, WalletClient } from 'viem'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+import type { ChainManager } from '@/services/ChainManager.js'
+import type { TransactionData } from '@/types/lend/index.js'
+import type { EOATransactionReceipt } from '@/wallet/core/wallets/abstract/types/index.js'
+import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+
+export class TestWallet extends Wallet {
+  public readonly address: Address
+  public readonly signer: LocalAccount
+
+  constructor(
+    chainManager: ChainManager,
+    address: Address,
+    signer: LocalAccount,
+  ) {
+    super(chainManager)
+    this.address = address
+    this.signer = signer
+  }
+
+  async walletClient(_chainId: SupportedChainId): Promise<WalletClient> {
+    return {} as unknown as WalletClient
+  }
+
+  async send(
+    _transactionData: TransactionData,
+    _chainId: SupportedChainId,
+  ): Promise<EOATransactionReceipt> {
+    return {} as unknown as EOATransactionReceipt
+  }
+
+  async sendBatch(
+    _transactionData: TransactionData[],
+    _chainId: SupportedChainId,
+  ): Promise<EOATransactionReceipt[]> {
+    return [] as unknown as EOATransactionReceipt[]
+  }
+}

--- a/packages/sdk/src/wallet/core/wallets/abstract/__tests__/Wallet.spec.ts
+++ b/packages/sdk/src/wallet/core/wallets/abstract/__tests__/Wallet.spec.ts
@@ -1,15 +1,14 @@
-import type { Address, LocalAccount, WalletClient } from 'viem'
+import type { LocalAccount } from 'viem'
 import { unichain } from 'viem/chains'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { WalletLendNamespace } from '@/lend/namespaces/WalletLendNamespace.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import { fetchERC20Balance, fetchETHBalance } from '@/services/tokenBalance.js'
 import { SUPPORTED_TOKENS } from '@/supported/tokens.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { getRandomAddress } from '@/test/utils.js'
-import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import { TestWallet } from '@/wallet/core/wallets/abstract/__mocks__/TestWallet.js'
 
 vi.mock('@/services/tokenBalance.js', async () => {
   return {
@@ -17,26 +16,6 @@ vi.mock('@/services/tokenBalance.js', async () => {
     fetchERC20Balance: vi.fn().mockResolvedValue({} as unknown),
   }
 })
-
-class TestWallet extends Wallet {
-  public readonly address: Address
-  public readonly signer: LocalAccount
-
-  constructor(
-    chainManager: ChainManager,
-    address: Address,
-    signer: LocalAccount,
-  ) {
-    super(chainManager)
-    this.address = address
-    this.signer = signer
-  }
-
-  // Not used in these tests
-  async walletClient(_chainId: SupportedChainId): Promise<WalletClient> {
-    return {} as unknown as WalletClient
-  }
-}
 
 describe('Wallet (base)', () => {
   const chainManager = new MockChainManager({

--- a/packages/sdk/src/wallet/core/wallets/abstract/types/index.ts
+++ b/packages/sdk/src/wallet/core/wallets/abstract/types/index.ts
@@ -1,0 +1,42 @@
+import type { TransactionReceipt } from 'viem'
+import type { WaitForUserOperationReceiptReturnType } from 'viem/account-abstraction'
+
+/**
+ * Transaction receipt for EOA (Externally Owned Account) transactions.
+ *
+ * Standard Ethereum transaction receipt from regular transactions sent by EOA wallets.
+ */
+export type EOATransactionReceipt = TransactionReceipt<
+  bigint,
+  number,
+  'success' | 'reverted'
+>
+
+/**
+ * Transaction receipt for ERC-4337 UserOperations.
+ *
+ * Receipt from smart wallet transactions processed through bundlers.
+ * Contains `userOpHash` to identify the UserOperation.
+ */
+export type UserOperationTransactionReceipt =
+  WaitForUserOperationReceiptReturnType
+
+/**
+ * Return type for single transaction operations.
+ *
+ * Can be either an EOA transaction receipt or a UserOperation receipt,
+ * depending on the wallet type used.
+ */
+export type TransactionReturnType =
+  | EOATransactionReceipt
+  | UserOperationTransactionReceipt
+
+/**
+ * Return type for batch transaction operations.
+ *
+ * EOA wallets return an array of receipts (one per transaction), while
+ * smart wallets return a single UserOperation receipt for the entire batch.
+ */
+export type BatchTransactionReturnType =
+  | EOATransactionReceipt[]
+  | UserOperationTransactionReceipt

--- a/packages/sdk/src/wallet/core/wallets/eoa/EOAWallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/eoa/EOAWallet.ts
@@ -1,0 +1,96 @@
+import type {
+  Chain,
+  FallbackTransport,
+  HttpTransport,
+  LocalAccount,
+  WalletClient,
+} from 'viem'
+import { createWalletClient } from 'viem'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+import type { TransactionData } from '@/types/lend/index.js'
+import type { EOATransactionReceipt } from '@/wallet/core/wallets/abstract/types/index.js'
+import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+
+/**
+ * Base class for Externally Owned Account (EOA) wallets.
+ *
+ * EOA wallets send standard Ethereum transactions signed by a private key,
+ * without using ERC-4337 account abstraction features (bundlers, UserOperations, paymasters).
+ * Transactions are submitted directly to the network and processed by validators.
+ */
+export abstract class EOAWallet extends Wallet {
+  /**
+   * Create a WalletClient for this EOA wallet.
+   *
+   * Creates a viem-compatible WalletClient configured with this wallet's account
+   * and the specified chain. Supports fallback transport for multiple RPC URLs.
+   * @param chainId - The chain ID to create the wallet client for
+   * @returns Promise resolving to a WalletClient configured for the specified chain
+   */
+  async walletClient(
+    chainId: SupportedChainId,
+  ): Promise<
+    WalletClient<
+      | HttpTransport<undefined, false>
+      | FallbackTransport<Array<HttpTransport<undefined, false>>>,
+      Chain,
+      LocalAccount,
+      []
+    >
+  > {
+    return createWalletClient({
+      account: this.signer,
+      chain: this.chainManager.getChain(chainId),
+      transport: this.chainManager.getTransportForChain(chainId),
+    })
+  }
+
+  /**
+   * Send a single transaction from this EOA wallet.
+   *
+   * Creates a wallet client, sends the transaction, and waits for the receipt.
+   * @param transactionData - Transaction to send (to, value, data, etc.)
+   * @param chainId - Chain to send the transaction on
+   * @returns Promise resolving to the transaction receipt
+   */
+  async send(
+    transactionData: TransactionData,
+    chainId: SupportedChainId,
+  ): Promise<EOATransactionReceipt> {
+    const walletClient = await this.walletClient(chainId)
+    const txHash = await walletClient.sendTransaction(transactionData)
+    const publicClient = this.chainManager.getPublicClient(chainId)
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: txHash,
+    })
+    return receipt
+  }
+
+  /**
+   * Send multiple transactions sequentially from this EOA wallet.
+   *
+   * Executes transactions one at a time in order, waiting for 2 confirmations
+   * between each to ensure nonce updates. Returns an array of receipts.
+   * @param transactionData - Array of transactions to send
+   * @param chainId - Chain to send the transactions on
+   * @returns Promise resolving to array of transaction receipts (one per transaction)
+   */
+  async sendBatch(
+    transactionData: TransactionData[],
+    chainId: SupportedChainId,
+  ): Promise<EOATransactionReceipt[]> {
+    const receipts: EOATransactionReceipt[] = []
+    for (const tx of transactionData) {
+      const receipt = await this.send(tx, chainId)
+      const publicClient = this.chainManager.getPublicClient(chainId)
+      // wait an extra confirmation so give time for nonce to be updated
+      await publicClient.waitForTransactionReceipt({
+        hash: receipt.transactionHash,
+        confirmations: 2,
+      })
+      receipts.push(receipt)
+    }
+    return receipts
+  }
+}

--- a/packages/sdk/src/wallet/core/wallets/eoa/__mocks__/EOAWallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/eoa/__mocks__/EOAWallet.ts
@@ -1,0 +1,112 @@
+import type { Address, LocalAccount, WalletClient } from 'viem'
+import { vi } from 'vitest'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+import type { Asset } from '@/types/asset.js'
+import type { TransactionData } from '@/types/lend/index.js'
+import type { EOATransactionReceipt } from '@/wallet/core/wallets/abstract/types/index.js'
+import type { EOAWallet } from '@/wallet/core/wallets/eoa/EOAWallet.js'
+
+export type CreateEOAWalletMockOptions = {
+  /** Mock wallet address */
+  address?: Address
+  /** Mock signer */
+  signer?: LocalAccount
+  /** Custom implementation for walletClient */
+  walletClientImpl?: (chainId: SupportedChainId) => Promise<WalletClient>
+  /** Custom implementation for send */
+  sendImpl?: (
+    transactionData: TransactionData,
+    chainId: SupportedChainId,
+  ) => Promise<EOATransactionReceipt>
+  /** Custom implementation for sendBatch */
+  sendBatchImpl?: (
+    transactionData: TransactionData[],
+    chainId: SupportedChainId,
+  ) => Promise<EOATransactionReceipt[]>
+  /** Optional custom sendTokens implementation */
+  sendTokensImpl?: (
+    amount: number,
+    asset: Asset,
+    chainId: SupportedChainId,
+    recipientAddress: Address,
+  ) => Promise<TransactionData>
+}
+
+/**
+ * Create a mock EOAWallet instance
+ * @description Returns an object typed as `EOAWallet` with configurable
+ * implementations for `send`, `sendBatch`, and `walletClient`. Other abstract
+ * members are provided with minimal defaults or throw if invoked (unless overridden).
+ */
+export function createMock(
+  options: CreateEOAWalletMockOptions = {},
+): EOAWallet {
+  const defaultReceipt = {
+    transactionHash:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    blockNumber: 12345n,
+    status: 'success',
+  } as unknown as EOATransactionReceipt
+
+  const address: Address = (options.address ??
+    '0x0000000000000000000000000000000000000000') as Address
+  const signer: LocalAccount =
+    options.signer ?? ({ address, type: 'local' } as unknown as LocalAccount)
+
+  const walletClient = vi.fn(
+    async (chainId: SupportedChainId): Promise<WalletClient> => {
+      if (options.walletClientImpl) return options.walletClientImpl(chainId)
+      throw new Error('walletClient not implemented in EOAWallet mock')
+    },
+  )
+
+  const send = vi.fn(
+    async (
+      transactionData: TransactionData,
+      chainId: SupportedChainId,
+    ): Promise<EOATransactionReceipt> => {
+      if (options.sendImpl) return options.sendImpl(transactionData, chainId)
+      return defaultReceipt
+    },
+  )
+
+  const sendBatch = vi.fn(
+    async (
+      transactionData: TransactionData[],
+      chainId: SupportedChainId,
+    ): Promise<EOATransactionReceipt[]> => {
+      if (options.sendBatchImpl)
+        return options.sendBatchImpl(transactionData, chainId)
+      return [defaultReceipt]
+    },
+  )
+
+  const sendTokens = vi.fn(
+    async (
+      amount: number,
+      asset: Asset,
+      chainId: SupportedChainId,
+      recipientAddress: Address,
+    ): Promise<TransactionData> => {
+      if (options.sendTokensImpl)
+        return options.sendTokensImpl(amount, asset, chainId, recipientAddress)
+      throw new Error('sendTokens not implemented in EOAWallet mock')
+    },
+  )
+
+  const mock = {
+    get address() {
+      return address
+    },
+    get signer() {
+      return signer
+    },
+    walletClient,
+    send,
+    sendBatch,
+    sendTokens,
+  } as unknown as EOAWallet
+
+  return mock
+}

--- a/packages/sdk/src/wallet/core/wallets/eoa/__tests__/EOAWallet.spec.ts
+++ b/packages/sdk/src/wallet/core/wallets/eoa/__tests__/EOAWallet.spec.ts
@@ -1,0 +1,299 @@
+import type {
+  Address,
+  Chain,
+  Hex,
+  LocalAccount,
+  PublicClient,
+  WalletClient,
+} from 'viem'
+import { createWalletClient } from 'viem'
+import { unichain } from 'viem/chains'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChainManager } from '@/services/ChainManager.js'
+import { MockChainManager } from '@/test/MockChainManager.js'
+import { getRandomAddress } from '@/test/utils.js'
+import type { TransactionData } from '@/types/lend/index.js'
+import type { EOATransactionReceipt } from '@/wallet/core/wallets/abstract/types/index.js'
+import { EOAWallet } from '@/wallet/core/wallets/eoa/EOAWallet.js'
+
+vi.mock('viem', async () => ({
+  // @ts-ignore - importActual returns unknown
+  ...(await vi.importActual('viem')),
+  createWalletClient: vi.fn(),
+}))
+
+// Concrete implementation for testing abstract class
+class TestEOAWallet extends EOAWallet {
+  public readonly address: Address
+  public readonly signer: LocalAccount
+
+  constructor(
+    address: Address,
+    signer: LocalAccount,
+    chainManager: ChainManager,
+  ) {
+    super(chainManager)
+    this.address = address
+    this.signer = signer
+  }
+
+  static async create(
+    address: Address,
+    signer: LocalAccount,
+    chainManager: ChainManager,
+  ): Promise<TestEOAWallet> {
+    const wallet = new TestEOAWallet(address, signer, chainManager)
+    await wallet.initialize()
+    return wallet
+  }
+}
+
+const mockAddress = getRandomAddress()
+const mockChainManager = new MockChainManager({
+  supportedChains: [130], // Unichain
+}) as unknown as ChainManager
+
+const mockLocalAccount = {
+  address: mockAddress,
+  signMessage: vi.fn(),
+  sign: vi.fn(),
+  signTransaction: vi.fn(),
+  signTypedData: vi.fn(),
+} as unknown as LocalAccount
+
+const mockTransactionHash: Hex =
+  '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+
+const mockReceipt: EOATransactionReceipt = {
+  transactionHash: mockTransactionHash,
+  blockNumber: 12345n,
+  status: 'success',
+  from: mockAddress,
+  to: getRandomAddress(),
+  gasUsed: 21000n,
+} as EOATransactionReceipt
+
+describe('EOAWallet', () => {
+  let wallet: TestEOAWallet
+  let mockWalletClient: WalletClient
+  let mockPublicClient: PublicClient
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    // Setup mock wallet client
+    mockWalletClient = {
+      sendTransaction: vi.fn().mockResolvedValue(mockTransactionHash),
+    } as unknown as WalletClient
+
+    // Setup mock public client
+    mockPublicClient = {
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(mockReceipt),
+    } as unknown as PublicClient
+
+    // Mock chainManager methods
+    vi.spyOn(mockChainManager, 'getChain').mockReturnValue(
+      unichain as unknown as Chain,
+    )
+    vi.spyOn(mockChainManager, 'getRpcUrls').mockReturnValue([
+      'https://rpc1.example.com',
+      'https://rpc2.example.com',
+    ])
+    vi.spyOn(mockChainManager, 'getPublicClient').mockReturnValue(
+      mockPublicClient,
+    )
+
+    // Mock createWalletClient
+    vi.mocked(createWalletClient).mockResolvedValue(mockWalletClient)
+
+    wallet = await TestEOAWallet.create(
+      mockAddress,
+      mockLocalAccount,
+      mockChainManager,
+    )
+  })
+
+  describe('walletClient', () => {
+    it('should create a wallet client with correct configuration', async () => {
+      const walletClient = await wallet.walletClient(unichain.id)
+
+      expect(createWalletClient).toHaveBeenCalledOnce()
+      const callArgs = vi.mocked(createWalletClient).mock.calls[0][0]
+      expect(callArgs.account).toBe(mockLocalAccount)
+      expect(callArgs.chain).toBe(unichain)
+      expect(walletClient).toBe(mockWalletClient)
+    })
+  })
+
+  describe('send', () => {
+    const mockTransactionData: TransactionData = {
+      to: getRandomAddress(),
+      value: 1000000000000000000n, // 1 ETH
+      data: '0x',
+    }
+
+    it('should send a transaction and return receipt', async () => {
+      const receipt = await wallet.send(mockTransactionData, unichain.id)
+
+      expect(mockWalletClient.sendTransaction).toHaveBeenCalledWith(
+        mockTransactionData,
+      )
+      expect(mockChainManager.getPublicClient).toHaveBeenCalledWith(unichain.id)
+      expect(mockPublicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+        hash: mockTransactionHash,
+      })
+      expect(receipt).toBe(mockReceipt)
+    })
+
+    it('should create wallet client with correct chain', async () => {
+      await wallet.send(mockTransactionData, unichain.id)
+
+      expect(mockChainManager.getChain).toHaveBeenCalledWith(unichain.id)
+      expect(createWalletClient).toHaveBeenCalled()
+    })
+  })
+
+  describe('sendBatch', () => {
+    const mockTransactionData1: TransactionData = {
+      to: getRandomAddress(),
+      value: 1000000000000000000n,
+      data: '0x',
+    }
+
+    const mockTransactionData2: TransactionData = {
+      to: getRandomAddress(),
+      value: 2000000000000000000n,
+      data: '0xabcd',
+    }
+
+    const mockTransactionData3: TransactionData = {
+      to: getRandomAddress(),
+      value: 3000000000000000000n,
+      data: '0x1234',
+    }
+
+    const mockReceipt2: EOATransactionReceipt = {
+      ...mockReceipt,
+      transactionHash:
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex,
+    }
+
+    const mockReceipt3: EOATransactionReceipt = {
+      ...mockReceipt,
+      transactionHash:
+        '0x9876543210987654321098765432109876543210987654321098765432109876' as Hex,
+    }
+
+    beforeEach(() => {
+      vi.mocked(mockWalletClient.sendTransaction)
+        .mockResolvedValueOnce(mockReceipt.transactionHash)
+        .mockResolvedValueOnce(mockReceipt2.transactionHash)
+        .mockResolvedValueOnce(mockReceipt3.transactionHash)
+
+      vi.mocked(mockPublicClient.waitForTransactionReceipt)
+        .mockResolvedValueOnce(mockReceipt)
+        .mockResolvedValueOnce(mockReceipt)
+        .mockResolvedValueOnce(mockReceipt2)
+        .mockResolvedValueOnce(mockReceipt2)
+        .mockResolvedValueOnce(mockReceipt3)
+        .mockResolvedValueOnce(mockReceipt3)
+    })
+
+    it('should send multiple transactions sequentially', async () => {
+      const receipts = await wallet.sendBatch(
+        [mockTransactionData1, mockTransactionData2, mockTransactionData3],
+        unichain.id,
+      )
+
+      expect(receipts).toHaveLength(3)
+      expect(receipts[0]).toBe(mockReceipt)
+      expect(receipts[1]).toBe(mockReceipt2)
+      expect(receipts[2]).toBe(mockReceipt3)
+
+      expect(mockWalletClient.sendTransaction).toHaveBeenCalledTimes(3)
+      expect(mockWalletClient.sendTransaction).toHaveBeenNthCalledWith(
+        1,
+        mockTransactionData1,
+      )
+      expect(mockWalletClient.sendTransaction).toHaveBeenNthCalledWith(
+        2,
+        mockTransactionData2,
+      )
+      expect(mockWalletClient.sendTransaction).toHaveBeenNthCalledWith(
+        3,
+        mockTransactionData3,
+      )
+    })
+
+    it('should wait for extra confirmations after each transaction', async () => {
+      await wallet.sendBatch(
+        [mockTransactionData1, mockTransactionData2],
+        unichain.id,
+      )
+
+      // Should be called twice per transaction:
+      // 1. Initial wait in send()
+      // 2. Extra confirmation wait (confirmations: 2) in sendBatch()
+      expect(mockPublicClient.waitForTransactionReceipt).toHaveBeenCalledTimes(
+        4,
+      )
+
+      // Check that extra confirmation wait was called with confirmations: 2
+      expect(
+        mockPublicClient.waitForTransactionReceipt,
+      ).toHaveBeenNthCalledWith(2, {
+        hash: mockReceipt.transactionHash,
+        confirmations: 2,
+      })
+
+      expect(
+        mockPublicClient.waitForTransactionReceipt,
+      ).toHaveBeenNthCalledWith(4, {
+        hash: mockReceipt2.transactionHash,
+        confirmations: 2,
+      })
+    })
+
+    it('should get public client for each transaction', async () => {
+      await wallet.sendBatch(
+        [mockTransactionData1, mockTransactionData2],
+        unichain.id,
+      )
+
+      // Called twice per transaction (once in send, once for extra confirmation)
+      expect(mockChainManager.getPublicClient).toHaveBeenCalledTimes(4)
+      expect(mockChainManager.getPublicClient).toHaveBeenCalledWith(unichain.id)
+    })
+
+    it('should handle single transaction in batch', async () => {
+      const receipts = await wallet.sendBatch(
+        [mockTransactionData1],
+        unichain.id,
+      )
+
+      expect(receipts).toHaveLength(1)
+      expect(receipts[0]).toBe(mockReceipt)
+      expect(mockWalletClient.sendTransaction).toHaveBeenCalledOnce()
+    })
+
+    it('should return empty array for empty batch', async () => {
+      const receipts = await wallet.sendBatch([], unichain.id)
+
+      expect(receipts).toEqual([])
+      expect(mockWalletClient.sendTransaction).not.toHaveBeenCalled()
+    })
+
+    it('should maintain transaction order in results', async () => {
+      const receipts = await wallet.sendBatch(
+        [mockTransactionData1, mockTransactionData2, mockTransactionData3],
+        unichain.id,
+      )
+
+      // Verify order is preserved
+      expect(receipts[0].transactionHash).toBe(mockReceipt.transactionHash)
+      expect(receipts[1].transactionHash).toBe(mockReceipt2.transactionHash)
+      expect(receipts[2].transactionHash).toBe(mockReceipt3.transactionHash)
+    })
+  })
+})

--- a/packages/sdk/src/wallet/core/wallets/smart/abstract/SmartWallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/abstract/SmartWallet.ts
@@ -1,4 +1,4 @@
-import type { Address, WalletClient } from 'viem'
+import type { Address } from 'viem'
 import type { WaitForUserOperationReceiptReturnType } from 'viem/account-abstraction'
 
 import type { SupportedChainId } from '@/constants/supportedChains.js'
@@ -12,10 +12,6 @@ import type { Signer } from '@/wallet/core/wallets/smart/abstract/types/index.js
  * @description Abstract base class for smart wallet implementations (ERC-4337 compatible wallets).
  */
 export abstract class SmartWallet extends Wallet {
-  async walletClient(_chainId: SupportedChainId): Promise<WalletClient> {
-    throw new Error('walletClient is not supported on SmartWallet')
-  }
-
   /**
    * Send a transaction using this smart wallet
    * @description Executes a transaction through the smart wallet, handling gas sponsorship

--- a/packages/sdk/src/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.ts
@@ -3,6 +3,7 @@ import type { LocalAccount } from 'viem'
 import { getAddress } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type {
@@ -27,8 +28,9 @@ export class PrivyHostedWalletProvider extends HostedWalletProvider<
   constructor(
     private readonly privyClient: PrivyClient,
     chainManager: ChainManager,
+    lendProvider?: LendProvider<LendConfig>,
   ) {
-    super(chainManager)
+    super(chainManager, lendProvider)
   }
 
   async toActionsWallet(
@@ -39,6 +41,7 @@ export class PrivyHostedWalletProvider extends HostedWalletProvider<
       walletId: params.walletId,
       address: getAddress(params.address),
       chainManager: this.chainManager,
+      lendProvider: this.lendProvider,
     })
   }
 

--- a/packages/sdk/src/wallet/node/providers/hosted/privy/__tests__/PrivyHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/privy/__tests__/PrivyHostedWalletProvider.spec.ts
@@ -7,6 +7,7 @@ import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
 import { createMockPrivyClient } from '@/test/MockPrivyClient.js'
 import { getRandomAddress } from '@/test/utils.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
 import { PrivyWallet } from '@/wallet/node/wallets/hosted/privy/PrivyWallet.js'
@@ -62,6 +63,31 @@ describe('PrivyHostedWalletProvider', () => {
       await expect(
         provider.toActionsWallet({ walletId: 'id', address: '0x123' }),
       ).rejects.toBeTruthy()
+    })
+
+    it('forwards lendProvider when provided to constructor', async () => {
+      const privy = createMockPrivyClient('app', 'secret')
+      const mockLendProvider = {} as LendProvider<LendConfig>
+      const provider = new PrivyHostedWalletProvider(
+        privy,
+        mockChainManager,
+        mockLendProvider,
+      )
+      const spy = vi.spyOn(PrivyWallet, 'create')
+
+      const id = 'mock-wallet-123'
+      const addr = getRandomAddress().toLowerCase()
+
+      await provider.toActionsWallet({
+        walletId: id,
+        address: addr as Address,
+      })
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lendProvider: mockLendProvider,
+        }),
+      )
     })
   })
 

--- a/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
@@ -28,8 +28,12 @@ export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegist
       validateOptions(options): options is NodeOptionsMap['privy'] {
         return Boolean((options as NodeOptionsMap['privy'])?.privyClient)
       },
-      create({ chainManager }, options) {
-        return new PrivyHostedWalletProvider(options.privyClient, chainManager)
+      create({ chainManager, lendProvider }, options) {
+        return new PrivyHostedWalletProvider(
+          options.privyClient,
+          chainManager,
+          lendProvider,
+        )
       },
     })
 
@@ -39,8 +43,12 @@ export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegist
         const o = options as NodeOptionsMap['turnkey']
         return Boolean(o?.client)
       },
-      create({ chainManager }, options) {
-        return new TurnkeyHostedWalletProvider(options.client, chainManager)
+      create({ chainManager, lendProvider }, options) {
+        return new TurnkeyHostedWalletProvider(
+          options.client,
+          chainManager,
+          lendProvider,
+        )
       },
     })
   }

--- a/packages/sdk/src/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
@@ -4,6 +4,7 @@ import type { TurnkeyServerClient } from '@turnkey/sdk-server'
 import type { LocalAccount } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { NodeToActionsOptionsMap } from '@/wallet/node/providers/hosted/types/index.js'
@@ -32,8 +33,9 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
       | TurnkeyServerClient
       | TurnkeySDKClientBase,
     chainManager: ChainManager,
+    lendProvider?: LendProvider<LendConfig>,
   ) {
-    super(chainManager)
+    super(chainManager, lendProvider)
   }
 
   /**
@@ -54,6 +56,7 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
       signWith: params.signWith,
       ethereumAddress: params.ethereumAddress,
       chainManager: this.chainManager,
+      lendProvider: this.lendProvider,
     })
   }
 

--- a/packages/sdk/src/wallet/node/providers/hosted/turnkey/__tests__/TurnkeyHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/turnkey/__tests__/TurnkeyHostedWalletProvider.spec.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { TurnkeyHostedWalletProvider } from '@/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
 import { TurnkeyWallet } from '@/wallet/node/wallets/hosted/turnkey/TurnkeyWallet.js'
 import * as createSignerUtil from '@/wallet/node/wallets/hosted/turnkey/utils/createSigner.js'
@@ -89,6 +90,32 @@ describe('TurnkeyHostedWalletProvider', () => {
       })
 
       expect(actionsWallet).toBe(fakeWallet)
+    })
+
+    it('forwards lendProvider when provided to constructor', async () => {
+      const turnkeyClient = {} as unknown as TurnkeyClient
+      const mockLendProvider = {} as LendProvider<LendConfig>
+      const provider = new TurnkeyHostedWalletProvider(
+        turnkeyClient,
+        mockChainManager,
+        mockLendProvider,
+      )
+      const spyTurnkeyWalletCreate = vi
+        .spyOn(TurnkeyWallet, 'create')
+        .mockResolvedValueOnce({
+          address: '0xabc',
+        } as unknown as TurnkeyWallet)
+
+      await provider.toActionsWallet({
+        organizationId: 'org_123',
+        signWith: 'key_abc',
+      })
+
+      expect(spyTurnkeyWalletCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lendProvider: mockLendProvider,
+        }),
+      )
     })
   })
 

--- a/packages/sdk/src/wallet/node/wallets/hosted/privy/PrivyWallet.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/privy/PrivyWallet.ts
@@ -1,23 +1,16 @@
 import type { PrivyClient } from '@privy-io/server-auth'
-import {
-  type Address,
-  createWalletClient,
-  fallback,
-  http,
-  type LocalAccount,
-  type WalletClient,
-} from 'viem'
+import { type Address, type LocalAccount } from 'viem'
 
-import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
-import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
+import { EOAWallet } from '@/wallet/core/wallets/eoa/EOAWallet.js'
 import { createSigner } from '@/wallet/node/wallets/hosted/privy/utils/createSigner.js'
 
 /**
  * Privy wallet implementation
  * @description Wallet implementation using Privy service
  */
-export class PrivyWallet extends Wallet {
+export class PrivyWallet extends EOAWallet {
   public walletId: string
   public signer!: LocalAccount
   public readonly address: Address
@@ -34,8 +27,9 @@ export class PrivyWallet extends Wallet {
     walletId: string,
     address: Address,
     chainManager: ChainManager,
+    lendProvider?: LendProvider<LendConfig>,
   ) {
-    super(chainManager)
+    super(chainManager, lendProvider)
     this.privyClient = privyClient
     this.walletId = walletId
     this.address = address
@@ -46,35 +40,17 @@ export class PrivyWallet extends Wallet {
     walletId: string
     address: Address
     chainManager: ChainManager
+    lendProvider?: LendProvider<LendConfig>
   }): Promise<PrivyWallet> {
     const wallet = new PrivyWallet(
       params.privyClient,
       params.walletId,
       params.address,
       params.chainManager,
+      params.lendProvider,
     )
     await wallet.initialize()
     return wallet
-  }
-
-  /**
-   * Create a WalletClient for this Privy wallet
-   * @description Creates a viem-compatible WalletClient configured with this wallet's account
-   * and the specified chain. The returned client can be used to send transactions and interact
-   * with smart contracts using Privy's signing infrastructure under the hood.
-   * @param chainId - The chain ID to create the wallet client for
-   * @returns Promise resolving to a WalletClient configured for the specified chain
-   * @throws Error if chain is not supported or wallet client creation fails
-   */
-  async walletClient(chainId: SupportedChainId): Promise<WalletClient> {
-    const rpcUrls = this.chainManager.getRpcUrls(chainId)
-    return createWalletClient({
-      account: this.signer,
-      chain: this.chainManager.getChain(chainId),
-      transport: rpcUrls?.length
-        ? fallback(rpcUrls.map((rpcUrl) => http(rpcUrl)))
-        : http(),
-    })
   }
 
   /**

--- a/packages/sdk/src/wallet/node/wallets/hosted/turnkey/TurnkeyWallet.ts
+++ b/packages/sdk/src/wallet/node/wallets/hosted/turnkey/TurnkeyWallet.ts
@@ -1,19 +1,18 @@
 import type { TurnkeySDKClientBase } from '@turnkey/core'
 import type { TurnkeyClient } from '@turnkey/http'
 import type { TurnkeyServerClient } from '@turnkey/sdk-server'
-import type { Address, LocalAccount, WalletClient } from 'viem'
-import { createWalletClient, fallback, http } from 'viem'
+import type { Address, LocalAccount } from 'viem'
 
-import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
-import { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
+import { EOAWallet } from '@/wallet/core/wallets/eoa/EOAWallet.js'
 import { createSigner } from '@/wallet/node/wallets/hosted/turnkey/utils/createSigner.js'
 
 /**
  * Turnkey wallet implementation
  * @description Wallet implementation using Turnkey service
  */
-export class TurnkeyWallet extends Wallet {
+export class TurnkeyWallet extends EOAWallet {
   public address!: Address
   public signer!: LocalAccount
   /**
@@ -45,10 +44,17 @@ export class TurnkeyWallet extends Wallet {
     organizationId: string
     signWith: string
     ethereumAddress?: string
+    lendProvider?: LendProvider<LendConfig>
   }) {
-    const { chainManager, client, organizationId, signWith, ethereumAddress } =
-      params
-    super(chainManager)
+    const {
+      chainManager,
+      client,
+      organizationId,
+      signWith,
+      ethereumAddress,
+      lendProvider,
+    } = params
+    super(chainManager, lendProvider)
     this.client = client
     this.organizationId = organizationId
     this.signWith = signWith
@@ -61,21 +67,11 @@ export class TurnkeyWallet extends Wallet {
     organizationId: string
     signWith: string
     ethereumAddress?: string
+    lendProvider?: LendProvider<LendConfig>
   }): Promise<TurnkeyWallet> {
     const wallet = new TurnkeyWallet(params)
     await wallet.initialize()
     return wallet
-  }
-
-  async walletClient(chainId: SupportedChainId): Promise<WalletClient> {
-    const rpcUrls = this.chainManager.getRpcUrls(chainId)
-    return createWalletClient({
-      account: this.signer,
-      chain: this.chainManager.getChain(chainId),
-      transport: rpcUrls?.length
-        ? fallback(rpcUrls.map((rpcUrl) => http(rpcUrl)))
-        : http(),
-    })
   }
 
   protected async performInitialization() {

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.ts
@@ -1,6 +1,7 @@
 import type { LocalAccount } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { ReactToActionsOptionsMap } from '@/wallet/react/providers/hosted/types/index.js'
@@ -18,8 +19,11 @@ export class DynamicHostedWalletProvider extends HostedWalletProvider<
   /**
    * Create a new Dynamic wallet provider
    */
-  constructor(chainManager: ChainManager) {
-    super(chainManager)
+  constructor(
+    chainManager: ChainManager,
+    lendProvider?: LendProvider<LendConfig>,
+  ) {
+    super(chainManager, lendProvider)
   }
 
   async toActionsWallet(
@@ -28,6 +32,7 @@ export class DynamicHostedWalletProvider extends HostedWalletProvider<
     return DynamicWallet.create({
       dynamicWallet: params.wallet,
       chainManager: this.chainManager,
+      lendProvider: this.lendProvider,
     })
   }
 

--- a/packages/sdk/src/wallet/react/providers/hosted/dynamic/__tests__/DynamicHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/dynamic/__tests__/DynamicHostedWalletProvider.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
 import type { DynamicHostedWalletToActionsWalletOptions } from '@/wallet/react/providers/hosted/types/index.js'
 import * as createSignerUtil from '@/wallet/react/wallets/hosted/dynamic/utils/createSigner.js'
@@ -40,6 +41,33 @@ describe('DynamicHostedWalletProvider', () => {
         chainManager: mockChainManager,
       })
       expect(result).toBe(mockResult)
+    })
+
+    it('forwards lendProvider when provided to constructor', async () => {
+      const mockChainManager = new MockChainManager({
+        supportedChains: [1],
+      }) as unknown as ChainManager
+      const mockLendProvider = {} as any
+      const provider = new DynamicHostedWalletProvider(
+        mockChainManager,
+        mockLendProvider as LendProvider<LendConfig>,
+      )
+
+      const mockDynamicWallet = {
+        __brand: 'dynamic-wallet',
+      } as unknown as DynamicHostedWalletToActionsWalletOptions['wallet']
+      const mockResult = { __brand: 'actions-wallet' }
+      vi.mocked(DynamicWallet.create).mockResolvedValueOnce(mockResult)
+
+      await provider.toActionsWallet({
+        wallet: mockDynamicWallet,
+      })
+
+      expect(DynamicWallet.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lendProvider: mockLendProvider,
+        }),
+      )
     })
   })
 

--- a/packages/sdk/src/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.ts
@@ -1,6 +1,7 @@
 import type { LocalAccount } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { ReactToActionsOptionsMap } from '@/wallet/react/providers/hosted/types/index.js'
@@ -18,8 +19,11 @@ export class PrivyHostedWalletProvider extends HostedWalletProvider<
    * Create a new Privy wallet provider
    * @param chainManager Chain manager for RPC, chain info, and transports
    */
-  constructor(chainManager: ChainManager) {
-    super(chainManager)
+  constructor(
+    chainManager: ChainManager,
+    lendProvider?: LendProvider<LendConfig>,
+  ) {
+    super(chainManager, lendProvider)
   }
 
   async toActionsWallet(
@@ -29,6 +33,7 @@ export class PrivyHostedWalletProvider extends HostedWalletProvider<
     const wallet = await PrivyWallet.create({
       chainManager: this.chainManager,
       connectedWallet,
+      lendProvider: this.lendProvider,
     })
     return wallet
   }

--- a/packages/sdk/src/wallet/react/providers/hosted/privy/__tests__/PrivyHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/privy/__tests__/PrivyHostedWalletProvider.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { PrivyHostedWalletProvider } from '@/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.js'
 import { PrivyWallet } from '@/wallet/react/wallets/hosted/privy/PrivyWallet.js'
 import * as createSignerUtil from '@/wallet/react/wallets/hosted/privy/utils/createSigner.js'
@@ -41,6 +42,34 @@ describe('PrivyHostedWalletProvider (React)', () => {
         connectedWallet: mockConnectedWallet,
       })
       expect(result).toBe(mockActionsWallet)
+    })
+
+    it('forwards lendProvider when provided to constructor', async () => {
+      const mockChainManager = new MockChainManager({
+        supportedChains: [1],
+      }) as unknown as ChainManager
+      const mockLendProvider = {} as any
+      const provider = new PrivyHostedWalletProvider(
+        mockChainManager,
+        mockLendProvider as LendProvider<LendConfig>,
+      )
+      const mockActionsWallet = {
+        __brand: 'actions-wallet',
+      } as unknown as PrivyWallet
+      const mockConnectedWallet = {
+        __brand: 'privy-connected-wallet',
+      } as unknown as ConnectedWallet
+      vi.mocked(PrivyWallet.create).mockResolvedValueOnce(mockActionsWallet)
+
+      await provider.toActionsWallet({
+        connectedWallet: mockConnectedWallet,
+      })
+
+      expect(PrivyWallet.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lendProvider: mockLendProvider,
+        }),
+      )
     })
   })
 

--- a/packages/sdk/src/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.ts
@@ -1,6 +1,7 @@
 import type { LocalAccount } from 'viem'
 
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { HostedWalletProvider } from '@/wallet/core/providers/hosted/abstract/HostedWalletProvider.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { ReactToActionsOptionsMap } from '@/wallet/react/providers/hosted/types/index.js'
@@ -24,8 +25,11 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
    * @param organizationId - Turnkey organization ID that owns the signing key
    * @param chainManager - Chain manager used to resolve chains and RPC transports
    */
-  constructor(chainManager: ChainManager) {
-    super(chainManager)
+  constructor(
+    chainManager: ChainManager,
+    lendProvider?: LendProvider<LendConfig>,
+  ) {
+    super(chainManager, lendProvider)
   }
 
   /**
@@ -49,6 +53,7 @@ export class TurnkeyHostedWalletProvider extends HostedWalletProvider<
       signWith,
       ethereumAddress,
       chainManager: this.chainManager,
+      lendProvider: this.lendProvider,
     })
   }
 

--- a/packages/sdk/src/wallet/react/providers/hosted/turnkey/__tests__/TurnkeyHostedWalletProvider.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/hosted/turnkey/__tests__/TurnkeyHostedWalletProvider.spec.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import { MockChainManager } from '@/test/MockChainManager.js'
+import type { LendConfig, LendProvider } from '@/types/lend/index.js'
 import { TurnkeyHostedWalletProvider } from '@/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
 import { TurnkeyWallet } from '@/wallet/react/wallets/hosted/turnkey/TurnkeyWallet.js'
 import * as createSignerUtil from '@/wallet/react/wallets/hosted/turnkey/utils/createSigner.js'
@@ -83,6 +84,32 @@ describe('TurnkeyHostedWalletProvider', () => {
       })
 
       expect(actionsWallet).toBe(fakeWallet)
+    })
+
+    it('forwards lendProvider when provided to constructor', async () => {
+      const turnkeyClient = {} as unknown as TurnkeySDKClientBase
+      const mockLendProvider = {} as unknown as LendProvider<LendConfig>
+      const provider = new TurnkeyHostedWalletProvider(
+        mockChainManager,
+        mockLendProvider,
+      )
+      const spyTurnkeyWalletCreate = vi
+        .spyOn(TurnkeyWallet, 'create')
+        .mockResolvedValueOnce({
+          address: '0xabc',
+        } as unknown as TurnkeyWallet)
+
+      await provider.toActionsWallet({
+        client: turnkeyClient,
+        organizationId: 'org_123',
+        signWith: 'key_abc',
+      })
+
+      expect(spyTurnkeyWalletCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lendProvider: mockLendProvider,
+        }),
+      )
     })
   })
 

--- a/packages/sdk/src/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.ts
@@ -29,8 +29,8 @@ export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegis
       validateOptions(_options): _options is ReactOptionsMap['dynamic'] {
         return true
       },
-      create({ chainManager }, _options) {
-        return new DynamicHostedWalletProvider(chainManager)
+      create({ chainManager, lendProvider }, _options) {
+        return new DynamicHostedWalletProvider(chainManager, lendProvider)
       },
     })
 
@@ -39,8 +39,8 @@ export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegis
       validateOptions(_options): _options is ReactOptionsMap['privy'] {
         return true
       },
-      create({ chainManager }, _options) {
-        return new PrivyHostedWalletProvider(chainManager)
+      create({ chainManager, lendProvider }, _options) {
+        return new PrivyHostedWalletProvider(chainManager, lendProvider)
       },
     })
 
@@ -49,8 +49,8 @@ export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegis
       validateOptions(_options): _options is ReactOptionsMap['turnkey'] {
         return true
       },
-      create({ chainManager }, _options) {
-        return new TurnkeyHostedWalletProvider(chainManager)
+      create({ chainManager, lendProvider }, _options) {
+        return new TurnkeyHostedWalletProvider(chainManager, lendProvider)
       },
     })
   }


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/actions/issues/175

## Key Changes

Create `EOAWallet` abstraction
-  Created new `EOAWallet` abstract class that extends Wallet to represent Externally Owned Account wallets
-  Implements `send()` and `sendBatch()` for standard EOA transaction flows
-  `sendBatch()` executes transactions sequentially with 2-confirmation waits between each to handle nonce management

`Wallet` base class updates
-  Added abstract `send()` and `sendBatch()` methods to `Wallet` base class
-  Moved `lend` namespace initialization into `Wallet` constructor for consistent lending functionality across all wallet types

`HostedWallet` refactor
-  Updated all hosted wallet implementations (Privy, Turnkey, Dynamic) to extend `EOAWallet` instead of `Wallet`
-  Hosted wallets now inherit EOA transaction behavior automatically