### PR TITLE
Backend preview builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,22 @@
 [build]
-  command = "pnpm --filter @eth-optimism/actions-sdk build && pnpm --filter actions-ui build"
+  command = "pnpm --filter @eth-optimism/actions-sdk build && pnpm --filter @eth-optimism/actions-service build && pnpm --filter actions-ui build"
   publish = "packages/demo/frontend/dist"
 
 [build.environment]
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
+
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+
+# Rewrite /api/* to the backend Netlify Function
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/api"
+  status = 200
+
+# Set VITE_ACTIONS_API_URL for deploy previews so frontend hits the co-deployed backend
+[context.deploy-preview.environment]
+  VITE_ACTIONS_API_URL = "/api"
 

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -1,0 +1,18 @@
+import { initializeActions } from '../../packages/demo/backend/src/config/actions.js'
+import { createApp } from '../../packages/demo/backend/src/createApp.js'
+
+// Initialize Actions SDK once on cold start
+initializeActions()
+
+const app = createApp()
+
+export default async (request: Request) => {
+  // Strip /api prefix — the Netlify rewrite sends /api/wallet here,
+  // but the Hono routes expect /wallet
+  const url = new URL(request.url)
+  const strippedPath = url.pathname.replace(/^\/api/, '') || '/'
+  const newUrl = new URL(strippedPath + url.search, url.origin)
+  const newRequest = new Request(newUrl.toString(), request)
+
+  return app.fetch(newRequest)
+}

--- a/packages/demo/backend/src/app.ts
+++ b/packages/demo/backend/src/app.ts
@@ -3,8 +3,8 @@ import { serve } from '@hono/node-server'
 import { Option } from 'commander'
 
 import { initializeActions } from '@/config/actions.js'
-import { createApp } from '@/createApp.js'
 import { env } from '@/config/env.js'
+import { createApp } from '@/createApp.js'
 
 class ActionsApp extends App {
   private server: ReturnType<typeof serve> | null = null

--- a/packages/demo/backend/src/app.ts
+++ b/packages/demo/backend/src/app.ts
@@ -1,13 +1,10 @@
 import { App } from '@eth-optimism/utils-app'
 import { serve } from '@hono/node-server'
 import { Option } from 'commander'
-import { Hono } from 'hono'
-import { cors } from 'hono/cors'
 
 import { initializeActions } from '@/config/actions.js'
+import { createApp } from '@/createApp.js'
 import { env } from '@/config/env.js'
-import { actionsMiddleware } from '@/middleware/actions.js'
-import { router } from '@/router.js'
 
 class ActionsApp extends App {
   private server: ReturnType<typeof serve> | null = null
@@ -34,40 +31,7 @@ class ActionsApp extends App {
   }
 
   protected async main(): Promise<void> {
-    const app = new Hono()
-
-    // Enable CORS for frontend communication
-    app.use(
-      '*',
-      cors({
-        origin: (origin) => {
-          // Allow localhost for development
-          if (origin.startsWith('http://localhost:')) return origin
-
-          // Allow production domains
-          if (origin === 'https://actions-ui.netlify.app') return origin
-          if (origin === 'https://actions.money') return origin
-          if (origin === 'https://actions.optimism.io') return origin
-
-          // Allow Netlify deploy previews (e.g., https://deploy-preview-123--actions-ui.netlify.app)
-          if (
-            origin.match(
-              /^https:\/\/deploy-preview-\d+--actions-ui\.netlify\.app$/,
-            )
-          ) {
-            return origin
-          }
-
-          return null
-        },
-        allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-        allowHeaders: ['Content-Type', 'Authorization', 'privy-id-token'],
-      }),
-    )
-
-    // Apply Actions middleware (initialization already happened at startup)
-    app.use('*', actionsMiddleware)
-    app.route('/', router)
+    const app = createApp()
 
     this.logger.info('starting actions service on port %s', this.options.port)
 

--- a/packages/demo/backend/src/createApp.ts
+++ b/packages/demo/backend/src/createApp.ts
@@ -1,0 +1,42 @@
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+
+import { actionsMiddleware } from '@/middleware/actions.js'
+import { router } from '@/router.js'
+
+export function createApp(): Hono {
+  const app = new Hono()
+
+  app.use(
+    '*',
+    cors({
+      origin: (origin) => {
+        // Allow localhost for development
+        if (origin.startsWith('http://localhost:')) return origin
+
+        // Allow production domains
+        if (origin === 'https://actions-ui.netlify.app') return origin
+        if (origin === 'https://actions.money') return origin
+        if (origin === 'https://actions.optimism.io') return origin
+
+        // Allow Netlify deploy previews (e.g., https://deploy-preview-123--actions-ui.netlify.app)
+        if (
+          origin.match(
+            /^https:\/\/deploy-preview-\d+--actions-ui\.netlify\.app$/,
+          )
+        ) {
+          return origin
+        }
+
+        return null
+      },
+      allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      allowHeaders: ['Content-Type', 'Authorization', 'privy-id-token'],
+    }),
+  )
+
+  app.use('*', actionsMiddleware)
+  app.route('/', router)
+
+  return app
+}

--- a/packages/demo/frontend/src/envVars.ts
+++ b/packages/demo/frontend/src/envVars.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 const envVarSchema = z.object({
   VITE_ACTIONS_API_URL: z
     .string()
-    .url()
     .default(
       import.meta.env.MODE === 'production'
         ? 'https://dev-verbs-service.optimism.io'


### PR DESCRIPTION
## Problem

The Uniswap branch introduces new demo backend endpoints, but we have no way to test in preview build because we don't deploy preview backend builds.

## Solution

Add ephemeral backend deploy previews by wrapping the Hono app as a Netlify Function so PR preview URLs serve both frontend and backend from the same origin.

- [ ] Add staging backend env vars to netlify 