### PR TITLE
fix(frontend): bind swap quotes to wallet

### DIFF
--- a/packages/demo/frontend/src/components/earn/EarnWithFrontendWallet.spec.ts
+++ b/packages/demo/frontend/src/components/earn/EarnWithFrontendWallet.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  Asset,
+  SupportedChainId,
+  SwapQuote,
+  TransactionReturnType,
+} from '@eth-optimism/actions-sdk/react'
+import type { Address } from 'viem'
+
+import { buildFrontendWalletOperations } from './EarnWithFrontendWallet'
+
+const CHAIN_ID = 84532 as SupportedChainId
+const TOKEN_IN = '0x1111111111111111111111111111111111111111' as Address
+const TOKEN_OUT = '0x2222222222222222222222222222222222222222' as Address
+
+const assetIn: Asset = {
+  type: 'erc20',
+  address: { [CHAIN_ID]: TOKEN_IN },
+  metadata: {
+    decimals: 6,
+    name: 'USD Coin',
+    symbol: 'USDC',
+  },
+}
+
+const assetOut: Asset = {
+  type: 'erc20',
+  address: { [CHAIN_ID]: TOKEN_OUT },
+  metadata: {
+    decimals: 18,
+    name: 'Optimism',
+    symbol: 'OP',
+  },
+}
+
+describe('buildFrontendWalletOperations', () => {
+  it('quotes swaps through wallet.swap.getQuote so the recipient is bound to the wallet', async () => {
+    const walletQuote = {
+      assetIn,
+      assetOut,
+      chainId: CHAIN_ID,
+      amountIn: 10,
+      amountInRaw: 10_000_000n,
+      amountOut: 5,
+      amountOutRaw: 5_000_000_000_000_000_000n,
+      amountOutMin: 4.9,
+      amountOutMinRaw: 4_900_000_000_000_000_000n,
+      price: 0.5,
+      priceImpact: 0.01,
+      slippage: 0.005,
+      deadline: 1_700_000_000,
+      recipient: '0x515f8fC39dD14AD674AdB305C51559b3d4fFc85a' as Address,
+      provider: 'uniswap',
+      quotedAt: 1_700_000_000,
+      expiration: 1_700_000_060,
+      execution: {
+        routerAddress: '0x3333333333333333333333333333333333333333' as Address,
+        swapCalldata: '0x1234',
+        value: 0n,
+      },
+    } satisfies SwapQuote
+
+    const walletGetQuote = vi.fn().mockResolvedValue(walletQuote)
+    const actionsGetQuote = vi.fn()
+    const wallet = {
+      address: walletQuote.recipient,
+      getBalance: vi.fn(),
+      sendBatch: vi.fn<() => Promise<TransactionReturnType>>(),
+      lend: {
+        getPosition: vi.fn(),
+        openPosition: vi.fn(),
+        closePosition: vi.fn(),
+      },
+      swap: {
+        execute: vi.fn(),
+        getQuote: walletGetQuote,
+      },
+    }
+    const actions = {
+      lend: { getMarkets: vi.fn() },
+      swap: {
+        getMarkets: vi.fn(),
+        getQuote: actionsGetQuote,
+      },
+      getSupportedAssets: vi.fn().mockReturnValue([assetIn, assetOut]),
+    }
+
+    const operations = buildFrontendWalletOperations(wallet, actions)
+
+    const result = await operations.getSwapQuote({
+      tokenInAddress: TOKEN_IN,
+      tokenOutAddress: TOKEN_OUT,
+      chainId: CHAIN_ID,
+      amountIn: 10,
+      provider: 'uniswap',
+    })
+
+    expect(result).toEqual(walletQuote)
+    expect(walletGetQuote).toHaveBeenCalledWith({
+      assetIn,
+      assetOut,
+      chainId: CHAIN_ID,
+      amountIn: 10,
+      amountOut: undefined,
+      provider: 'uniswap',
+    })
+    expect(actionsGetQuote).not.toHaveBeenCalled()
+  })
+})

--- a/packages/demo/frontend/src/components/earn/EarnWithFrontendWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithFrontendWallet.tsx
@@ -1,11 +1,7 @@
-import { encodeFunctionData, type Address } from 'viem'
 import type {
   Wallet,
-  SupportedChainId,
-  Asset,
   ReactProviderTypes,
 } from '@eth-optimism/actions-sdk/react'
-import { mintableErc20Abi } from '@/abis/mintableErc20Abi'
 import { getBlockExplorerUrl } from '@/utils/blockExplorer'
 import Earn from './Earn'
 import {
@@ -16,8 +12,8 @@ import {
 import { useMemo } from 'react'
 import { createActions } from '@eth-optimism/actions-sdk/react'
 import { createActionsConfig } from '@/config/actions'
-import { actionsApi } from '@/api/actionsApi'
 import type { EarnOperations } from '@/hooks/useLendProvider'
+import { mintDemoAsset } from '@/utils/demoAssetMinting'
 
 export interface EarnWithFrontendWalletProps {
   wallet: Wallet | null
@@ -52,54 +48,7 @@ export function buildFrontendWalletOperations(
     getTokenBalances: async () => wallet.getBalance(),
     getMarkets: async () => actions.lend.getMarkets(),
     getPosition: async (marketId) => wallet.lend!.getPosition({ marketId }),
-    mintAsset: async (asset: Asset) => {
-      const walletAddress = wallet.address
-      const chainId = asset.address
-        ? Object.keys(asset.address).find(
-            (key) => asset.address[key as unknown as SupportedChainId],
-          )
-        : undefined
-
-      if (!chainId) throw new Error('No chain available for asset')
-
-      if (asset.metadata.symbol === 'ETH' && asset.type === 'native') {
-        await actionsApi.dripEthToWallet(walletAddress)
-        return
-      }
-
-      const amountInDecimals = BigInt(
-        Math.floor(parseFloat('100') * Math.pow(10, asset.metadata.decimals)),
-      )
-      const tokenAddress = asset.address[parseInt(chainId) as SupportedChainId]
-
-      if (!tokenAddress || tokenAddress === 'native') {
-        throw new Error(
-          `Asset ${asset.metadata.symbol} not available on chain ${chainId}`,
-        )
-      }
-
-      const result = await wallet.sendBatch(
-        [
-          {
-            to: tokenAddress as Address,
-            data: encodeFunctionData({
-              abi: mintableErc20Abi,
-              functionName: 'mint',
-              args: [walletAddress, amountInDecimals],
-            }),
-            value: 0n,
-          },
-        ],
-        parseInt(chainId) as SupportedChainId,
-      )
-
-      if ('blockExplorerUrl' in result && result.blockExplorerUrl) {
-        return { blockExplorerUrls: [result.blockExplorerUrl as string] }
-      }
-      if ('blockExplorerUrls' in result && result.blockExplorerUrls) {
-        return { blockExplorerUrls: result.blockExplorerUrls as string[] }
-      }
-    },
+    mintAsset: async (asset) => mintDemoAsset(wallet, asset),
     openPosition: async (params) => wallet.lend!.openPosition(params),
     closePosition: async (params) => wallet.lend!.closePosition(params),
     executeSwap: async (quote) => {

--- a/packages/demo/frontend/src/components/earn/EarnWithFrontendWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithFrontendWallet.tsx
@@ -33,6 +33,112 @@ function useActions<T extends ReactProviderTypes>(hostedWalletProviderType: T) {
   return useMemo(() => createActions(config), [config])
 }
 
+type FrontendWalletOperationsWallet = Pick<Wallet, 'address' | 'getBalance'> & {
+  sendBatch: Wallet['sendBatch']
+  lend: NonNullable<Wallet['lend']>
+  swap: NonNullable<Wallet['swap']>
+}
+
+type FrontendWalletOperationsActions = Pick<
+  ReturnType<typeof createActions>,
+  'getSupportedAssets' | 'lend' | 'swap'
+>
+
+export function buildFrontendWalletOperations(
+  wallet: FrontendWalletOperationsWallet,
+  actions: FrontendWalletOperationsActions,
+): EarnOperations {
+  return {
+    getTokenBalances: async () => wallet.getBalance(),
+    getMarkets: async () => actions.lend.getMarkets(),
+    getPosition: async (marketId) => wallet.lend!.getPosition({ marketId }),
+    mintAsset: async (asset: Asset) => {
+      const walletAddress = wallet.address
+      const chainId = asset.address
+        ? Object.keys(asset.address).find(
+            (key) => asset.address[key as unknown as SupportedChainId],
+          )
+        : undefined
+
+      if (!chainId) throw new Error('No chain available for asset')
+
+      if (asset.metadata.symbol === 'ETH' && asset.type === 'native') {
+        await actionsApi.dripEthToWallet(walletAddress)
+        return
+      }
+
+      const amountInDecimals = BigInt(
+        Math.floor(parseFloat('100') * Math.pow(10, asset.metadata.decimals)),
+      )
+      const tokenAddress = asset.address[parseInt(chainId) as SupportedChainId]
+
+      if (!tokenAddress || tokenAddress === 'native') {
+        throw new Error(
+          `Asset ${asset.metadata.symbol} not available on chain ${chainId}`,
+        )
+      }
+
+      const result = await wallet.sendBatch(
+        [
+          {
+            to: tokenAddress as Address,
+            data: encodeFunctionData({
+              abi: mintableErc20Abi,
+              functionName: 'mint',
+              args: [walletAddress, amountInDecimals],
+            }),
+            value: 0n,
+          },
+        ],
+        parseInt(chainId) as SupportedChainId,
+      )
+
+      if ('blockExplorerUrl' in result && result.blockExplorerUrl) {
+        return { blockExplorerUrls: [result.blockExplorerUrl as string] }
+      }
+      if ('blockExplorerUrls' in result && result.blockExplorerUrls) {
+        return { blockExplorerUrls: result.blockExplorerUrls as string[] }
+      }
+    },
+    openPosition: async (params) => wallet.lend!.openPosition(params),
+    closePosition: async (params) => wallet.lend!.closePosition(params),
+    executeSwap: async (quote) => {
+      const receipt = await wallet.swap!.execute(quote)
+      const txReceipt = receipt.receipt
+      const blockExplorerUrl = getBlockExplorerUrl(
+        quote.chainId,
+        txReceipt as Parameters<typeof getBlockExplorerUrl>[1],
+      )
+      return { blockExplorerUrl }
+    },
+    getConfiguredAssets: async () => actions.getSupportedAssets(),
+    getSwapMarkets: async () => actions.swap.getMarkets(),
+    getSwapQuote: async (params) => {
+      try {
+        const assets = actions.getSupportedAssets()
+        const assetIn = assets.find(
+          (a) => a.address[params.chainId] === params.tokenInAddress,
+        )
+        const assetOut = assets.find(
+          (a) => a.address[params.chainId] === params.tokenOutAddress,
+        )
+        if (!assetIn || !assetOut) return null
+
+        return await wallet.swap!.getQuote({
+          assetIn,
+          assetOut,
+          chainId: params.chainId,
+          amountIn: params.amountIn,
+          amountOut: params.amountOut,
+          provider: params.provider,
+        })
+      } catch {
+        return null
+      }
+    },
+  }
+}
+
 /**
  * Wrapper for frontend wallet providers (Dynamic, Turnkey)
  * Builds operations object and delegates to Earn
@@ -47,96 +153,7 @@ export function EarnWithFrontendWallet({
   const actions = useActions(hostedWalletProviderType)
 
   const operations = useMemo<EarnOperations>(
-    () => ({
-      getTokenBalances: async () => wallet!.getBalance(),
-      getMarkets: async () => actions.lend.getMarkets(),
-      getPosition: async (marketId) => wallet!.lend!.getPosition({ marketId }),
-      mintAsset: async (asset: Asset) => {
-        const walletAddress = wallet!.address
-        const chainId = asset.address
-          ? Object.keys(asset.address).find(
-              (key) => asset.address[key as unknown as SupportedChainId],
-            )
-          : undefined
-
-        if (!chainId) throw new Error('No chain available for asset')
-
-        if (asset.metadata.symbol === 'ETH' && asset.type === 'native') {
-          await actionsApi.dripEthToWallet(walletAddress)
-          return
-        }
-
-        const amountInDecimals = BigInt(
-          Math.floor(parseFloat('100') * Math.pow(10, asset.metadata.decimals)),
-        )
-        const tokenAddress =
-          asset.address[parseInt(chainId) as SupportedChainId]
-
-        if (!tokenAddress || tokenAddress === 'native') {
-          throw new Error(
-            `Asset ${asset.metadata.symbol} not available on chain ${chainId}`,
-          )
-        }
-
-        const result = await wallet!.sendBatch(
-          [
-            {
-              to: tokenAddress as Address,
-              data: encodeFunctionData({
-                abi: mintableErc20Abi,
-                functionName: 'mint',
-                args: [walletAddress, amountInDecimals],
-              }),
-              value: 0n,
-            },
-          ],
-          parseInt(chainId) as SupportedChainId,
-        )
-
-        if ('blockExplorerUrl' in result && result.blockExplorerUrl) {
-          return { blockExplorerUrls: [result.blockExplorerUrl as string] }
-        }
-        if ('blockExplorerUrls' in result && result.blockExplorerUrls) {
-          return { blockExplorerUrls: result.blockExplorerUrls as string[] }
-        }
-      },
-      openPosition: async (params) => wallet!.lend!.openPosition(params),
-      closePosition: async (params) => wallet!.lend!.closePosition(params),
-      executeSwap: async (quote) => {
-        const receipt = await wallet!.swap!.execute(quote)
-        const txReceipt = receipt.receipt
-        const blockExplorerUrl = getBlockExplorerUrl(
-          quote.chainId,
-          txReceipt as Parameters<typeof getBlockExplorerUrl>[1],
-        )
-        return { blockExplorerUrl }
-      },
-      getConfiguredAssets: async () => actions.getSupportedAssets(),
-      getSwapMarkets: async () => actions.swap.getMarkets(),
-      getSwapQuote: async (params) => {
-        try {
-          const assets = actions.getSupportedAssets()
-          const assetIn = assets.find(
-            (a) => a.address[params.chainId] === params.tokenInAddress,
-          )
-          const assetOut = assets.find(
-            (a) => a.address[params.chainId] === params.tokenOutAddress,
-          )
-          if (!assetIn || !assetOut) return null
-
-          return await actions.swap.getQuote({
-            assetIn,
-            assetOut,
-            chainId: params.chainId,
-            amountIn: params.amountIn,
-            amountOut: params.amountOut,
-            provider: params.provider,
-          })
-        } catch {
-          return null
-        }
-      },
-    }),
+    () => buildFrontendWalletOperations(wallet!, actions),
     [wallet, actions],
   )
 

--- a/packages/demo/frontend/src/components/earn/EarnWithServerWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithServerWallet.tsx
@@ -51,6 +51,7 @@ function buildSwapOperations(
           tokenInAddress: tokenInAddress as Address,
           tokenOutAddress: tokenOutAddress as Address,
           chainId: quote.chainId,
+          provider: quote.provider,
         },
         await getAuthHeaders(),
       )

--- a/packages/demo/frontend/src/utils/demoAssetMinting.ts
+++ b/packages/demo/frontend/src/utils/demoAssetMinting.ts
@@ -1,0 +1,77 @@
+import { encodeFunctionData, type Address } from 'viem'
+import type {
+  Asset,
+  SupportedChainId,
+  TransactionReturnType,
+  Wallet,
+} from '@eth-optimism/actions-sdk/react'
+
+import { mintableErc20Abi } from '@/abis/mintableErc20Abi'
+import { actionsApi } from '@/api/actionsApi'
+
+type FrontendMintWallet = Pick<Wallet, 'address'> & {
+  sendBatch: Wallet['sendBatch']
+}
+
+function resolveAssetChainId(asset: Asset): SupportedChainId {
+  const chainId = asset.address
+    ? Object.keys(asset.address).find(
+        (key) => asset.address[key as unknown as SupportedChainId],
+      )
+    : undefined
+
+  if (!chainId) {
+    throw new Error('No chain available for asset')
+  }
+
+  return parseInt(chainId) as SupportedChainId
+}
+
+function buildExplorerResult(result: TransactionReturnType) {
+  if ('blockExplorerUrl' in result && result.blockExplorerUrl) {
+    return { blockExplorerUrls: [result.blockExplorerUrl as string] }
+  }
+  if ('blockExplorerUrls' in result && result.blockExplorerUrls) {
+    return { blockExplorerUrls: result.blockExplorerUrls as string[] }
+  }
+}
+
+export async function mintDemoAsset(
+  wallet: FrontendMintWallet,
+  asset: Asset,
+): Promise<{ blockExplorerUrls?: string[] } | void> {
+  const chainId = resolveAssetChainId(asset)
+
+  if (asset.metadata.symbol === 'ETH' && asset.type === 'native') {
+    await actionsApi.dripEthToWallet(wallet.address)
+    return
+  }
+
+  const tokenAddress = asset.address[chainId]
+  if (!tokenAddress || tokenAddress === 'native') {
+    throw new Error(
+      `Asset ${asset.metadata.symbol} not available on chain ${chainId}`,
+    )
+  }
+
+  const amountInDecimals = BigInt(
+    Math.floor(parseFloat('100') * Math.pow(10, asset.metadata.decimals)),
+  )
+
+  const result = await wallet.sendBatch(
+    [
+      {
+        to: tokenAddress as Address,
+        data: encodeFunctionData({
+          abi: mintableErc20Abi,
+          functionName: 'mint',
+          args: [wallet.address, amountInDecimals],
+        }),
+        value: 0n,
+      },
+    ],
+    chainId,
+  )
+
+  return buildExplorerResult(result)
+}


### PR DESCRIPTION
# Problem
Frontend-hosted wallet swaps were failing immediately at execution time with a recipient mismatch error.

This started after [#434](https://github.com/ethereum-optimism/actions/pull/434), which changed `wallet.swap.execute(...)` to fail when a quote is bound to a different recipient instead of silently rewriting the recipient during execution.

The frontend wallet path was still generating swap quotes through the read-only actions namespace instead of the wallet namespace. That produced swap calldata bound to a placeholder recipient rather than the active wallet address, so execution was rejected before the transaction could be submitted.

The server-wallet path also dropped the selected swap provider during execution, which could cause quote selection and execution to diverge.

# Solution
Generate frontend-wallet swap quotes through `wallet.swap.getQuote(...)` so the recipient is bound to the connected wallet before execution.

Forward the selected provider through the server-wallet execute path so quote selection and execution stay aligned across wallet modes.

Added a regression test covering the frontend-wallet quote path.
