### PR TITLE
CLI: Borrow commands

### DIFF
--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -27,6 +27,13 @@ actions --json wallet balance --chain base-sepolia
   asset and/or one chain (no wallet).
 - `actions lend market --market <name>` - inspect one market by name
   (no wallet).
+- `actions borrow markets [--collateral <symbol>] [--borrow-asset <symbol>]
+  [--chain <name> | --chain-id <id>]` - borrow markets across configured
+  providers, optionally filtered (no wallet).
+- `actions borrow market --market <name>` - inspect one borrow market
+  by name (no wallet).
+- `actions borrow position --market <name> --wallet <address>` - read any
+  wallet's borrow position (no `PRIVATE_KEY` required).
 - `actions swap markets [--chain <name>]` - all swap markets across
   configured providers (no wallet).
 - `actions swap market --pool <id> --chain <name>` - inspect one swap
@@ -49,6 +56,24 @@ actions --json wallet balance --chain base-sepolia
   withdraw assets. Pass `--max` to withdraw the wallet's full balance in
   the market (the CLI fetches the position first; subject to inflight
   interest accrual).
+- `actions wallet borrow position --market <name>` - the wallet's current
+  collateral, debt, LTV, and health factor in a borrow market.
+- `actions wallet borrow open --market <name> --borrow-amount <n>
+  [--collateral-amount <n>] [--approval-mode <exact|max>]` - borrow
+  against existing or newly-deposited collateral. No `--max` (open path
+  only accepts strict amounts).
+- `actions wallet borrow close --market <name> [--borrow-amount <n> |
+  --borrow-max] [--collateral-amount <n> | --collateral-max]` - unwind a
+  position. Each leg is independently xor'd; the borrow leg is required.
+  `--*-max` resolves on-chain at dispatch time so interest-accrual dust
+  doesn't strand the position.
+- `actions wallet borrow deposit-collateral --market <name> --amount <n>
+  [--approval-mode <exact|max>]` - top up collateral without changing
+  debt.
+- `actions wallet borrow withdraw-collateral --market <name>
+  (--amount <n> | --max)` - pull collateral back without touching debt.
+- `actions wallet borrow repay --market <name> (--amount <n> | --max)
+  [--approval-mode <exact|max>]` - repay debt without touching collateral.
 - `actions wallet swap execute --in <symbol> --out <symbol>
   (--amount-in <n> | --amount-out <n>) --chain <name>
   [--provider uniswap|velodrome] [--slippage <pct>]` - execute a swap
@@ -77,6 +102,12 @@ demo, fund the EOA with testnet ETH on Base Sepolia.
   and hyphens are ignored, so `gauntlet-usdc` and `gauntletusdc`
   resolve to the same entry. The market entry carries its own chain
   and asset, so no `--chain` is needed.
+- **Markets (borrow)** - same name-based resolution as lend, plus `/`
+  is stripped (so `Demo dUSDC / OP` and `demo-dusdc-op` collapse to the
+  same key). Borrow market identifiers are discriminated unions (e.g.
+  `{ kind: 'morpho-blue', marketId: '0x...', chainId: ... }`); the CLI
+  forwards the resolved config to the SDK so a future second provider
+  variant adds no CLI work.
 - **Markets (swap)** - addressed pair-wise via `--in/--out/--chain` for
   quotes and execution. `--pool <id>` is only used for direct
   `swap market` lookups; the `poolId` surfaces in `swap markets`.
@@ -182,6 +213,68 @@ NL -> command examples:
 - "deposit 0.5 ETH into Aave on op-sepolia" -> `actions --json wallet lend open --market aave-eth --amount 0.5`
 - "withdraw 5 USDC from Gauntlet" -> `actions --json wallet lend close --market gauntlet-usdc --amount 5`
 - "how much do I have in Gauntlet" -> `actions --json wallet lend position --market gauntlet-usdc`
+
+## Borrow semantics
+
+The wallet-scoped write verbs (`open`, `close`, `deposit-collateral`,
+`withdraw-collateral`, `repay`) emit a structured envelope on stdout:
+
+```json
+{
+  "action": "open" | "close" | "depositCollateral" | "withdrawCollateral" | "repay",
+  "market": {
+    "name": "...",
+    "marketId": { "kind": "morpho-blue", "marketId": "0x...", "chainId": ... },
+    "chainId": ...,
+    "provider": "morpho"
+  },
+  "borrowAmount":     <number | "max">,
+  "collateralAmount": <number | "max">,
+  "transactions": [ { "transactionHash": "0x...", "status": "success", ... } ],
+  "ltv": <number | null>,
+  "healthFactor": <number | null>,
+  "liquidationPriceFormatted": "<string>"
+}
+```
+
+`borrowAmount` / `collateralAmount` echo what the verb touched (the
+inverse pair is omitted; e.g. `repay` reports only `borrowAmount`). The
+literal string `"max"` means the SDK resolved the full balance at
+dispatch time. `ltv` and `healthFactor` come from the SDK's
+`positionAfter` snapshot and are `null` when the action left no debt
+(divide-by-zero guard); they are omitted when the SDK did not surface a
+`positionAfter`. `transactions` is always an array, normalised the same
+way as lend / swap.
+
+A receipt with `status: "reverted"` is normalised to a `code: "onchain"`
+error envelope on stderr (exit 5).
+
+`actions borrow position --market <name> --wallet <address>` reads any
+wallet's position without needing `PRIVATE_KEY`; the CLI checksums the
+address (viem `getAddress`) before forwarding. `wallet borrow position`
+uses the connected wallet instead.
+
+`borrow markets` / `borrow market` / both `position` commands return the
+SDK shapes verbatim with bigints stringified. Position fields `ltv` and
+`healthFactor` are `null` when there is no outstanding debt.
+
+NL -> command examples:
+
+- "what borrow markets are available" -> `actions --json borrow markets`
+- "borrow 1 OP against 2 USDC of collateral on the demo market" ->
+  `actions --json wallet borrow open --market demo-dusdc-op --borrow-amount 1 --collateral-amount 2`
+- "close my borrow position completely" ->
+  `actions --json wallet borrow close --market demo-dusdc-op --borrow-max --collateral-max`
+- "repay all my debt on demo dUSDC/OP" ->
+  `actions --json wallet borrow repay --market demo-dusdc-op --max`
+- "withdraw all collateral from demo dUSDC/OP" ->
+  `actions --json wallet borrow withdraw-collateral --market demo-dusdc-op --max`
+- "top up 5 USDC of collateral on demo dUSDC/OP" ->
+  `actions --json wallet borrow deposit-collateral --market demo-dusdc-op --amount 5`
+- "what's the health factor of 0x... on demo dUSDC/OP" ->
+  `actions --json borrow position --market demo-dusdc-op --wallet 0x...`
+- "how am I doing in demo dUSDC/OP" ->
+  `actions --json wallet borrow position --market demo-dusdc-op`
 
 ## Swap semantics
 

--- a/packages/cli/src/commands/__tests__/actionsBorrowPosition.test.ts
+++ b/packages/cli/src/commands/__tests__/actionsBorrowPosition.test.ts
@@ -1,0 +1,123 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { runBorrowPosition } from '@/commands/actions/borrow/position.js'
+import * as baseCtx from '@/context/baseContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+describe('runBorrowPosition (read-only, with --wallet)', () => {
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const mockActions = (
+    getPosition: (params: unknown) => Promise<unknown>,
+  ): void => {
+    vi.spyOn(baseCtx, 'baseContext').mockReturnValue({
+      config: getDemoConfig(),
+      actions: { borrow: { getPosition } } as never,
+    })
+  }
+
+  const samplePosition = () => ({
+    marketId: {
+      kind: 'morpho-blue',
+      marketId: '0xdeadbeef',
+      chainId: 84532,
+    },
+    collateralAsset: { metadata: { symbol: 'USDC_DEMO' } },
+    collateralAmount: 1000n,
+    collateralAmountFormatted: '0.001',
+    borrowAsset: { metadata: { symbol: 'OP_DEMO' } },
+    borrowAmount: 200n,
+    borrowAmountFormatted: '0.0000000000000002',
+    healthFactor: null,
+    liquidationPrice: 0n,
+    liquidationPriceFormatted: '0',
+    borrowApy: 0.05,
+    liquidationBonus: 0.05,
+    ltv: null,
+    maxLtv: 0.86,
+  })
+
+  it('checksums --wallet and forwards it to actions.borrow.getPosition', async () => {
+    const captured: unknown[] = []
+    mockActions(async (params) => {
+      captured.push(params)
+      return samplePosition()
+    })
+    // Lowercase address that needs checksum normalisation.
+    const lower = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
+    await runBorrowPosition({ market: 'demo-dusdc-op', wallet: lower })
+    const call = captured[0] as {
+      marketId: { kind: string; marketId: string; chainId: number }
+      walletAddress: string
+    }
+    expect(call.marketId.kind).toBe('morpho-blue')
+    expect(call.marketId.chainId).toBe(84532)
+    // viem's getAddress() returns the EIP-55 checksum form.
+    expect(call.walletAddress).toBe(
+      '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+    )
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.healthFactor).toBeNull()
+    expect(body.ltv).toBeNull()
+  })
+
+  it('rejects a malformed --wallet address with CliError(validation)', async () => {
+    mockActions(async () => samplePosition())
+    try {
+      await runBorrowPosition({
+        market: 'demo-dusdc-op',
+        wallet: 'not-an-address',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/Invalid --wallet/)
+    }
+  })
+
+  it('rejects unknown markets with CliError(validation)', async () => {
+    mockActions(async () => samplePosition())
+    try {
+      await runBorrowPosition({
+        market: 'no-such-market',
+        wallet: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it('maps RPC failures to CliError(network)', async () => {
+    mockActions(async () => {
+      throw new Error('HTTP request failed')
+    })
+    try {
+      await runBorrowPosition({
+        market: 'demo-dusdc-op',
+        wallet: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('network')
+      expect((err as CliError).retryable).toBe(true)
+    }
+  })
+})

--- a/packages/cli/src/commands/__tests__/borrowMarket.test.ts
+++ b/packages/cli/src/commands/__tests__/borrowMarket.test.ts
@@ -1,0 +1,88 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { runBorrowMarket } from '@/commands/actions/borrow/market.js'
+import * as baseCtx from '@/context/baseContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+describe('runBorrowMarket', () => {
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const mockActions = (getMarket: (id: unknown) => Promise<unknown>) => {
+    vi.spyOn(baseCtx, 'baseContext').mockReturnValue({
+      config: getDemoConfig(),
+      actions: { borrow: { getMarket } } as never,
+    })
+  }
+
+  it('forwards the resolved BorrowMarketConfig as the marketId argument', async () => {
+    const captured: unknown[] = []
+    mockActions(async (id) => {
+      captured.push(id)
+      return {
+        marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+        name: 'Demo dUSDC / OP',
+        collateralAsset: { metadata: { symbol: 'USDC_DEMO' } },
+        borrowAsset: { metadata: { symbol: 'OP_DEMO' } },
+        borrowApy: 0.05,
+        liquidationBonus: 0.05,
+        maxLtv: 0.86,
+        healthBufferPct: 0.05,
+        totalBorrowed: 0n,
+        totalCollateral: 0n,
+      }
+    })
+    await runBorrowMarket({ market: 'demo-dusdc-op' })
+    const arg = captured[0] as {
+      kind: string
+      marketId: string
+      chainId: number
+      collateralAsset: unknown
+      marketParams: unknown
+    }
+    expect(arg.kind).toBe('morpho-blue')
+    expect(arg.chainId).toBe(84532)
+    expect(arg.marketId).toMatch(/^0x[a-fA-F0-9]{64}$/)
+    expect(arg.collateralAsset).toBeDefined()
+    expect(arg.marketParams).toBeDefined()
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.name).toBe('Demo dUSDC / OP')
+  })
+
+  it('rejects unknown markets with CliError(validation)', async () => {
+    mockActions(async () => ({}))
+    try {
+      await runBorrowMarket({ market: 'no-such-market' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it('maps RPC failures to CliError(network)', async () => {
+    mockActions(async () => {
+      throw new Error('HTTP request failed')
+    })
+    try {
+      await runBorrowMarket({ market: 'demo-dusdc-op' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('network')
+    }
+  })
+})

--- a/packages/cli/src/commands/__tests__/borrowMarkets.test.ts
+++ b/packages/cli/src/commands/__tests__/borrowMarkets.test.ts
@@ -1,0 +1,128 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { runBorrowMarkets } from '@/commands/actions/borrow/markets.js'
+import * as baseCtx from '@/context/baseContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+describe('runBorrowMarkets', () => {
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const mockActions = (getMarkets: (params?: unknown) => Promise<unknown>) => {
+    vi.spyOn(baseCtx, 'baseContext').mockReturnValue({
+      config: getDemoConfig(),
+      actions: { borrow: { getMarkets } } as never,
+    })
+  }
+
+  it('emits the array of markets with bigints stringified', async () => {
+    mockActions(async () => [
+      {
+        marketId: {
+          kind: 'morpho-blue',
+          marketId: '0xdeadbeef',
+          chainId: 84532,
+        },
+        name: 'Demo dUSDC / OP',
+        collateralAsset: { metadata: { symbol: 'USDC_DEMO' } },
+        borrowAsset: { metadata: { symbol: 'OP_DEMO' } },
+        borrowApy: 0.05,
+        liquidationBonus: 0.05,
+        maxLtv: 0.86,
+        healthBufferPct: 0.05,
+        totalBorrowed: 1000000n,
+        totalCollateral: 999999n,
+      },
+    ])
+    await runBorrowMarkets()
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body).toHaveLength(1)
+    expect(body[0].name).toBe('Demo dUSDC / OP')
+    expect(body[0].totalBorrowed).toBe('1000000')
+    expect(body[0].marketId.kind).toBe('morpho-blue')
+  })
+
+  it('forwards --collateral as collateralAsset and --chain as chainId', async () => {
+    const captured: unknown[] = []
+    mockActions(async (params) => {
+      captured.push(params)
+      return []
+    })
+    await runBorrowMarkets({
+      collateral: 'USDC_DEMO',
+      chain: 'base-sepolia',
+    })
+    expect(captured).toHaveLength(1)
+    const call = captured[0] as {
+      collateralAsset?: { metadata: { symbol: string } }
+      borrowAsset?: unknown
+      chainId?: number
+    }
+    expect(call.collateralAsset?.metadata.symbol).toBe('USDC_DEMO')
+    expect(call.borrowAsset).toBeUndefined()
+    expect(call.chainId).toBe(84532)
+  })
+
+  it('forwards --borrow-asset as borrowAsset', async () => {
+    const captured: unknown[] = []
+    mockActions(async (params) => {
+      captured.push(params)
+      return []
+    })
+    await runBorrowMarkets({ borrowAsset: 'OP_DEMO' })
+    const call = captured[0] as {
+      borrowAsset?: { metadata: { symbol: string } }
+    }
+    expect(call.borrowAsset?.metadata.symbol).toBe('OP_DEMO')
+  })
+
+  it('rejects unknown --collateral with CliError(validation)', async () => {
+    mockActions(async () => [])
+    try {
+      await runBorrowMarkets({ collateral: 'NOSUCH' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it('rejects multi-chain --chain values with CliError(validation)', async () => {
+    mockActions(async () => [])
+    try {
+      await runBorrowMarkets({ chain: 'base-sepolia,op-sepolia' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/single chain/)
+    }
+  })
+
+  it('maps RPC failures to CliError(network)', async () => {
+    mockActions(async () => {
+      throw new Error('HTTP request failed. Status: ECONNREFUSED')
+    })
+    try {
+      await runBorrowMarkets()
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('network')
+      expect((err as CliError).retryable).toBe(true)
+    }
+  })
+})

--- a/packages/cli/src/commands/__tests__/requireBorrowCapability.test.ts
+++ b/packages/cli/src/commands/__tests__/requireBorrowCapability.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { requireBorrowCapability } from '@/commands/wallet/borrow/requireBorrowCapability.js'
+import { CliError } from '@/output/errors.js'
+
+describe('requireBorrowCapability', () => {
+  it('throws CliError(config) when wallet.has("borrow") is false', () => {
+    const wallet = {
+      has: (_n: string) => false,
+    } as never
+    try {
+      requireBorrowCapability(wallet)
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('config')
+      expect((err as CliError).message).toMatch(/Borrowing is not configured/)
+    }
+  })
+
+  it('passes through when wallet.has("borrow") is true', () => {
+    const wallet = {
+      has: (n: string) => n === 'borrow',
+      borrow: {},
+    } as never
+    expect(() => requireBorrowCapability(wallet)).not.toThrow()
+  })
+})

--- a/packages/cli/src/commands/__tests__/walletBorrowClose.test.ts
+++ b/packages/cli/src/commands/__tests__/walletBorrowClose.test.ts
@@ -1,0 +1,183 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ANVIL_ACCOUNT_0 } from '@/__mocks__/anvilAccounts.js'
+import { runWalletBorrowClose } from '@/commands/wallet/borrow/close.js'
+import { __resetEnvCacheForTests } from '@/config/env.js'
+import * as walletCtx from '@/context/walletContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+const successReceipt = (hash: string) => ({
+  transactionHash: hash,
+  status: 'success' as const,
+  blockNumber: 9n,
+  gasUsed: 50000n,
+})
+
+const wrap = (tx: ReturnType<typeof successReceipt>) => ({
+  action: 'close' as const,
+  marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+  receipt: tx,
+})
+
+describe('runWalletBorrowClose', () => {
+  const originalEnv = process.env
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PRIVATE_KEY: ANVIL_ACCOUNT_0 }
+    __resetEnvCacheForTests()
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    __resetEnvCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  const mockWallet = (closePosition: (params: unknown) => Promise<unknown>) => {
+    vi.spyOn(walletCtx, 'walletContext').mockResolvedValue({
+      config: getDemoConfig(),
+      actions: {} as never,
+      signer: {} as never,
+      wallet: {
+        address: '0xabc',
+        borrow: {
+          closePosition,
+          openPosition: async () => null,
+          depositCollateral: async () => null,
+          withdrawCollateral: async () => null,
+          repay: async () => null,
+        },
+        has: (n: string) => n === 'borrow',
+      } as never,
+    })
+  }
+
+  it('forwards { max: true } on both legs when --borrow-max + --collateral-max are set', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xclose'))
+    })
+    await runWalletBorrowClose({
+      market: 'demo-dusdc-op',
+      borrowMax: true,
+      collateralMax: true,
+    })
+    const call = captured[0] as {
+      borrowAmount: { max?: boolean }
+      collateralAmount: { max?: boolean }
+    }
+    expect(call.borrowAmount).toEqual({ max: true })
+    expect(call.collateralAmount).toEqual({ max: true })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.borrowAmount).toBe('max')
+    expect(body.collateralAmount).toBe('max')
+  })
+
+  it('wraps explicit amounts via { amount }', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xclose'))
+    })
+    await runWalletBorrowClose({
+      market: 'demo-dusdc-op',
+      borrowAmount: '0.5',
+      collateralAmount: '0.25',
+    })
+    const call = captured[0] as {
+      borrowAmount: { amount?: number }
+      collateralAmount: { amount?: number }
+    }
+    expect(call.borrowAmount).toEqual({ amount: 0.5 })
+    expect(call.collateralAmount).toEqual({ amount: 0.25 })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.borrowAmount).toBe(0.5)
+    expect(body.collateralAmount).toBe(0.25)
+  })
+
+  it('omits the collateral leg when neither flag is set', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xclose'))
+    })
+    await runWalletBorrowClose({
+      market: 'demo-dusdc-op',
+      borrowMax: true,
+    })
+    const call = captured[0] as { collateralAmount?: unknown }
+    expect(call.collateralAmount).toBeUndefined()
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.collateralAmount).toBeUndefined()
+  })
+
+  it('rejects --borrow-amount + --borrow-max with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowClose({
+        market: 'demo-dusdc-op',
+        borrowAmount: '1',
+        borrowMax: true,
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/not both/)
+    }
+  })
+
+  it('rejects --collateral-amount + --collateral-max with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowClose({
+        market: 'demo-dusdc-op',
+        borrowMax: true,
+        collateralAmount: '1',
+        collateralMax: true,
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/not both/)
+    }
+  })
+
+  it('rejects close with neither --borrow-amount nor --borrow-max as CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowClose({ market: 'demo-dusdc-op' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/required/)
+    }
+  })
+
+  it('maps reverted receipts to CliError(onchain)', async () => {
+    mockWallet(async () =>
+      wrap({ ...successReceipt('0xrevert'), status: 'reverted' } as never),
+    )
+    try {
+      await runWalletBorrowClose({
+        market: 'demo-dusdc-op',
+        borrowMax: true,
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('onchain')
+    }
+  })
+})

--- a/packages/cli/src/commands/__tests__/walletBorrowClose.test.ts
+++ b/packages/cli/src/commands/__tests__/walletBorrowClose.test.ts
@@ -180,4 +180,25 @@ describe('runWalletBorrowClose', () => {
       expect((err as CliError).code).toBe('onchain')
     }
   })
+
+  it('preserves null ltv/healthFactor from a fully-repaid position', async () => {
+    mockWallet(async () => ({
+      action: 'close' as const,
+      marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+      receipt: successReceipt('0xclose'),
+      positionAfter: {
+        ltv: null,
+        healthFactor: null,
+        liquidationPriceFormatted: '0',
+      },
+    }))
+    await runWalletBorrowClose({
+      market: 'demo-dusdc-op',
+      borrowMax: true,
+      collateralMax: true,
+    })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.ltv).toBeNull()
+    expect(body.healthFactor).toBeNull()
+  })
 })

--- a/packages/cli/src/commands/__tests__/walletBorrowDepositCollateral.test.ts
+++ b/packages/cli/src/commands/__tests__/walletBorrowDepositCollateral.test.ts
@@ -1,0 +1,118 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ANVIL_ACCOUNT_0 } from '@/__mocks__/anvilAccounts.js'
+import { runWalletBorrowDepositCollateral } from '@/commands/wallet/borrow/deposit-collateral.js'
+import { __resetEnvCacheForTests } from '@/config/env.js'
+import * as walletCtx from '@/context/walletContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+const successReceipt = (hash: string) => ({
+  transactionHash: hash,
+  status: 'success' as const,
+  blockNumber: 4n,
+  gasUsed: 30000n,
+})
+
+const wrap = (tx: ReturnType<typeof successReceipt>) => ({
+  action: 'depositCollateral' as const,
+  marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+  receipt: tx,
+})
+
+describe('runWalletBorrowDepositCollateral', () => {
+  const originalEnv = process.env
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PRIVATE_KEY: ANVIL_ACCOUNT_0 }
+    __resetEnvCacheForTests()
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    __resetEnvCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  const mockWallet = (
+    depositCollateral: (params: unknown) => Promise<unknown>,
+  ) => {
+    vi.spyOn(walletCtx, 'walletContext').mockResolvedValue({
+      config: getDemoConfig(),
+      actions: {} as never,
+      signer: {} as never,
+      wallet: {
+        address: '0xabc',
+        borrow: {
+          depositCollateral,
+          openPosition: async () => null,
+          closePosition: async () => null,
+          withdrawCollateral: async () => null,
+          repay: async () => null,
+        },
+        has: (n: string) => n === 'borrow',
+      } as never,
+    })
+  }
+
+  it('wraps --amount in { amount } and forwards approval-mode', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xdeposit'))
+    })
+    await runWalletBorrowDepositCollateral({
+      market: 'demo-dusdc-op',
+      amount: '5',
+      approvalMode: 'exact',
+    })
+    const call = captured[0] as {
+      amount: { amount: number }
+      approvalMode?: string
+    }
+    expect(call.amount).toEqual({ amount: 5 })
+    expect(call.approvalMode).toBe('exact')
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.action).toBe('depositCollateral')
+    expect(body.collateralAmount).toBe(5)
+    expect(body.borrowAmount).toBeUndefined()
+  })
+
+  it.each(['0', '-1', 'foo', '1e10'])(
+    'rejects --amount %p with CliError(validation)',
+    async (bad) => {
+      mockWallet(async () => wrap(successReceipt('0x')))
+      try {
+        await runWalletBorrowDepositCollateral({
+          market: 'demo-dusdc-op',
+          amount: bad,
+        })
+        throw new Error(`did not throw for ${bad}`)
+      } catch (err) {
+        expect(err).toBeInstanceOf(CliError)
+        expect((err as CliError).code).toBe('validation')
+      }
+    },
+  )
+
+  it('rejects unknown markets with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowDepositCollateral({
+        market: 'no-such-market',
+        amount: '1',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+})

--- a/packages/cli/src/commands/__tests__/walletBorrowOpen.test.ts
+++ b/packages/cli/src/commands/__tests__/walletBorrowOpen.test.ts
@@ -1,0 +1,246 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ANVIL_ACCOUNT_0 } from '@/__mocks__/anvilAccounts.js'
+import { runWalletBorrowOpen } from '@/commands/wallet/borrow/open.js'
+import { __resetEnvCacheForTests } from '@/config/env.js'
+import * as walletCtx from '@/context/walletContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+const successReceipt = (hash: string) => ({
+  transactionHash: hash,
+  status: 'success' as const,
+  blockNumber: 1n,
+  gasUsed: 21000n,
+})
+
+const wrap = (tx: ReturnType<typeof successReceipt>) => ({
+  action: 'open' as const,
+  marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+  receipt: tx,
+  transactionHash: tx.transactionHash,
+})
+
+describe('runWalletBorrowOpen', () => {
+  const originalEnv = process.env
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PRIVATE_KEY: ANVIL_ACCOUNT_0 }
+    __resetEnvCacheForTests()
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    __resetEnvCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  const mockWallet = (
+    openPosition: (params: unknown) => Promise<unknown>,
+    has: (n: string) => boolean = (n) => n === 'borrow',
+  ) => {
+    vi.spyOn(walletCtx, 'walletContext').mockResolvedValue({
+      config: getDemoConfig(),
+      actions: {} as never,
+      signer: {} as never,
+      wallet: {
+        address: '0xabc',
+        borrow: {
+          openPosition,
+          closePosition: async () => null,
+          depositCollateral: async () => null,
+          withdrawCollateral: async () => null,
+          repay: async () => null,
+        },
+        has,
+      } as never,
+    })
+  }
+
+  it('emits a structured envelope with the borrow + collateral legs', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xopen'))
+    })
+    await runWalletBorrowOpen({
+      market: 'demo-dusdc-op',
+      borrowAmount: '1',
+      collateralAmount: '2',
+    })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.action).toBe('open')
+    expect(body.market.name).toBe('Demo dUSDC / OP')
+    expect(body.market.provider).toBe('morpho')
+    expect(body.market.marketId.kind).toBe('morpho-blue')
+    expect(body.borrowAmount).toBe(1)
+    expect(body.collateralAmount).toBe(2)
+    expect(body.transactions).toHaveLength(1)
+    expect(body.transactions[0].transactionHash).toBe('0xopen')
+    const call = captured[0] as {
+      borrowAmount: { amount: number }
+      collateralAmount: { amount: number }
+      market: { kind: string; marketId: string }
+    }
+    expect(call.borrowAmount).toEqual({ amount: 1 })
+    expect(call.collateralAmount).toEqual({ amount: 2 })
+    expect(call.market.kind).toBe('morpho-blue')
+  })
+
+  it('omits collateralAmount when --collateral-amount is unset', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xopen'))
+    })
+    await runWalletBorrowOpen({
+      market: 'demo-dusdc-op',
+      borrowAmount: '5',
+    })
+    const call = captured[0] as { collateralAmount?: unknown }
+    expect(call.collateralAmount).toBeUndefined()
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.borrowAmount).toBe(5)
+    expect(body.collateralAmount).toBeUndefined()
+  })
+
+  it('forwards --approval-mode to the SDK when set', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0x'))
+    })
+    await runWalletBorrowOpen({
+      market: 'demo-dusdc-op',
+      borrowAmount: '1',
+      approvalMode: 'max',
+    })
+    const call = captured[0] as { approvalMode?: string }
+    expect(call.approvalMode).toBe('max')
+  })
+
+  it('rejects invalid --approval-mode with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowOpen({
+        market: 'demo-dusdc-op',
+        borrowAmount: '1',
+        approvalMode: 'infinite',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it('rejects unknown markets with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowOpen({
+        market: 'no-such-market',
+        borrowAmount: '1',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it.each(['0', '-1', 'foo', '1e10'])(
+    'rejects --borrow-amount %p with CliError(validation)',
+    async (bad) => {
+      mockWallet(async () => wrap(successReceipt('0x')))
+      try {
+        await runWalletBorrowOpen({
+          market: 'demo-dusdc-op',
+          borrowAmount: bad,
+        })
+        throw new Error(`did not throw for ${bad}`)
+      } catch (err) {
+        expect(err).toBeInstanceOf(CliError)
+        expect((err as CliError).code).toBe('validation')
+      }
+    },
+  )
+
+  it('rejects with CliError(config) when wallet.borrow is undefined', async () => {
+    mockWallet(
+      async () => wrap(successReceipt('0x')),
+      () => false,
+    )
+    try {
+      await runWalletBorrowOpen({
+        market: 'demo-dusdc-op',
+        borrowAmount: '1',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('config')
+    }
+  })
+
+  it('maps reverted receipts to CliError(onchain)', async () => {
+    mockWallet(async () =>
+      wrap({ ...successReceipt('0xrevert'), status: 'reverted' } as never),
+    )
+    try {
+      await runWalletBorrowOpen({
+        market: 'demo-dusdc-op',
+        borrowAmount: '1',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('onchain')
+    }
+  })
+
+  it('flattens a batched receipt array via toReceiptArray', async () => {
+    mockWallet(async () => ({
+      action: 'open' as const,
+      marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+      receipt: [successReceipt('0xapprove'), successReceipt('0xopen')],
+    }))
+    await runWalletBorrowOpen({
+      market: 'demo-dusdc-op',
+      borrowAmount: '1',
+      collateralAmount: '2',
+    })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.transactions).toHaveLength(2)
+    expect(body.transactions[0].transactionHash).toBe('0xapprove')
+    expect(body.transactions[1].transactionHash).toBe('0xopen')
+  })
+
+  it('decorates the envelope with positionAfter highlights when present', async () => {
+    mockWallet(async () => ({
+      action: 'open' as const,
+      marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+      receipt: successReceipt('0xopen'),
+      positionAfter: {
+        ltv: 0.5,
+        healthFactor: 1.72,
+        liquidationPriceFormatted: '1.234',
+      },
+    }))
+    await runWalletBorrowOpen({
+      market: 'demo-dusdc-op',
+      borrowAmount: '1',
+      collateralAmount: '2',
+    })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.ltv).toBe(0.5)
+    expect(body.healthFactor).toBe(1.72)
+    expect(body.liquidationPriceFormatted).toBe('1.234')
+  })
+})

--- a/packages/cli/src/commands/__tests__/walletBorrowPosition.test.ts
+++ b/packages/cli/src/commands/__tests__/walletBorrowPosition.test.ts
@@ -1,0 +1,131 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ANVIL_ACCOUNT_0 } from '@/__mocks__/anvilAccounts.js'
+import { runWalletBorrowPosition } from '@/commands/wallet/borrow/position.js'
+import { __resetEnvCacheForTests } from '@/config/env.js'
+import * as walletCtx from '@/context/walletContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+describe('runWalletBorrowPosition', () => {
+  const originalEnv = process.env
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PRIVATE_KEY: ANVIL_ACCOUNT_0 }
+    __resetEnvCacheForTests()
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    __resetEnvCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  const mockWallet = (
+    getPosition: (params: unknown) => Promise<unknown>,
+    walletAddress = '0xabc',
+    withBorrow = true,
+  ) => {
+    vi.spyOn(walletCtx, 'walletContext').mockResolvedValue({
+      config: getDemoConfig(),
+      actions: {
+        borrow: { getPosition },
+      } as never,
+      signer: {} as never,
+      wallet: {
+        address: walletAddress,
+        borrow: withBorrow
+          ? {
+              openPosition: async () => null,
+              closePosition: async () => null,
+              depositCollateral: async () => null,
+              withdrawCollateral: async () => null,
+              repay: async () => null,
+            }
+          : undefined,
+        has: (n: string) => n === 'borrow' && withBorrow,
+      } as never,
+    })
+  }
+
+  it('passes wallet.address as the walletAddress and the resolved config as marketId', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return {
+        marketId: {
+          kind: 'morpho-blue',
+          marketId: '0xdeadbeef',
+          chainId: 84532,
+        },
+        collateralAsset: { metadata: { symbol: 'USDC_DEMO' } },
+        collateralAmount: 100n,
+        collateralAmountFormatted: '0.0001',
+        borrowAsset: { metadata: { symbol: 'OP_DEMO' } },
+        borrowAmount: 50n,
+        borrowAmountFormatted: '5e-17',
+        healthFactor: 2.5,
+        liquidationPrice: 1234n,
+        liquidationPriceFormatted: '0.001234',
+        borrowApy: 0.05,
+        liquidationBonus: 0.05,
+        ltv: 0.4,
+        maxLtv: 0.86,
+      }
+    }, '0xd8da6bf26964af9d7eed9e03e53415d37aa96045')
+    await runWalletBorrowPosition({ market: 'demo-dusdc-op' })
+    const call = captured[0] as {
+      marketId: { kind: string; chainId: number }
+      walletAddress: string
+    }
+    expect(call.marketId.kind).toBe('morpho-blue')
+    expect(call.marketId.chainId).toBe(84532)
+    expect(call.walletAddress).toBe(
+      '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+    )
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.healthFactor).toBe(2.5)
+    expect(body.ltv).toBe(0.4)
+  })
+
+  it('rejects unknown markets with CliError(validation)', async () => {
+    mockWallet(async () => ({}))
+    try {
+      await runWalletBorrowPosition({ market: 'no-such-market' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it('rejects with CliError(config) when wallet.borrow is undefined', async () => {
+    mockWallet(async () => ({}), '0xabc', false)
+    try {
+      await runWalletBorrowPosition({ market: 'demo-dusdc-op' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('config')
+    }
+  })
+
+  it('rejects with CliError(config) when PRIVATE_KEY is missing', async () => {
+    delete process.env.PRIVATE_KEY
+    __resetEnvCacheForTests()
+    try {
+      await runWalletBorrowPosition({ market: 'demo-dusdc-op' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('config')
+    }
+  })
+})

--- a/packages/cli/src/commands/__tests__/walletBorrowRepay.test.ts
+++ b/packages/cli/src/commands/__tests__/walletBorrowRepay.test.ts
@@ -1,0 +1,142 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ANVIL_ACCOUNT_0 } from '@/__mocks__/anvilAccounts.js'
+import { runWalletBorrowRepay } from '@/commands/wallet/borrow/repay.js'
+import { __resetEnvCacheForTests } from '@/config/env.js'
+import * as walletCtx from '@/context/walletContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+const successReceipt = (hash: string) => ({
+  transactionHash: hash,
+  status: 'success' as const,
+  blockNumber: 4n,
+  gasUsed: 30000n,
+})
+
+const wrap = (tx: ReturnType<typeof successReceipt>) => ({
+  action: 'repay' as const,
+  marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+  receipt: tx,
+})
+
+describe('runWalletBorrowRepay', () => {
+  const originalEnv = process.env
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PRIVATE_KEY: ANVIL_ACCOUNT_0 }
+    __resetEnvCacheForTests()
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    __resetEnvCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  const mockWallet = (repay: (params: unknown) => Promise<unknown>) => {
+    vi.spyOn(walletCtx, 'walletContext').mockResolvedValue({
+      config: getDemoConfig(),
+      actions: {} as never,
+      signer: {} as never,
+      wallet: {
+        address: '0xabc',
+        borrow: {
+          repay,
+          openPosition: async () => null,
+          closePosition: async () => null,
+          depositCollateral: async () => null,
+          withdrawCollateral: async () => null,
+        },
+        has: (n: string) => n === 'borrow',
+      } as never,
+    })
+  }
+
+  it('wraps --amount in { amount } and forwards approval-mode', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xrepay'))
+    })
+    await runWalletBorrowRepay({
+      market: 'demo-dusdc-op',
+      amount: '0.25',
+      approvalMode: 'max',
+    })
+    const call = captured[0] as {
+      amount: { amount?: number; max?: boolean }
+      approvalMode?: string
+    }
+    expect(call.amount).toEqual({ amount: 0.25 })
+    expect(call.approvalMode).toBe('max')
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.action).toBe('repay')
+    expect(body.borrowAmount).toBe(0.25)
+    expect(body.collateralAmount).toBeUndefined()
+  })
+
+  it('forwards { max: true } when --max is set', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xrepay'))
+    })
+    await runWalletBorrowRepay({
+      market: 'demo-dusdc-op',
+      max: true,
+    })
+    const call = captured[0] as { amount: { max?: boolean } }
+    expect(call.amount).toEqual({ max: true })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.borrowAmount).toBe('max')
+  })
+
+  it('rejects --amount + --max with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowRepay({
+        market: 'demo-dusdc-op',
+        amount: '1',
+        max: true,
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it('rejects neither --amount nor --max with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowRepay({ market: 'demo-dusdc-op' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+
+  it('rejects invalid --approval-mode with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowRepay({
+        market: 'demo-dusdc-op',
+        amount: '1',
+        approvalMode: 'infinite',
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+    }
+  })
+})

--- a/packages/cli/src/commands/__tests__/walletBorrowWithdrawCollateral.test.ts
+++ b/packages/cli/src/commands/__tests__/walletBorrowWithdrawCollateral.test.ts
@@ -1,0 +1,125 @@
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ANVIL_ACCOUNT_0 } from '@/__mocks__/anvilAccounts.js'
+import { runWalletBorrowWithdrawCollateral } from '@/commands/wallet/borrow/withdraw-collateral.js'
+import { __resetEnvCacheForTests } from '@/config/env.js'
+import * as walletCtx from '@/context/walletContext.js'
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import { setJsonMode } from '@/output/mode.js'
+
+beforeEach(() => setJsonMode(true))
+afterEach(() => setJsonMode(false))
+
+const successReceipt = (hash: string) => ({
+  transactionHash: hash,
+  status: 'success' as const,
+  blockNumber: 4n,
+  gasUsed: 30000n,
+})
+
+const wrap = (tx: ReturnType<typeof successReceipt>) => ({
+  action: 'withdrawCollateral' as const,
+  marketId: { kind: 'morpho-blue', marketId: '0xff', chainId: 84532 },
+  receipt: tx,
+})
+
+describe('runWalletBorrowWithdrawCollateral', () => {
+  const originalEnv = process.env
+  let writeSpy: MockInstance
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PRIVATE_KEY: ANVIL_ACCOUNT_0 }
+    __resetEnvCacheForTests()
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    __resetEnvCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  const mockWallet = (
+    withdrawCollateral: (params: unknown) => Promise<unknown>,
+  ) => {
+    vi.spyOn(walletCtx, 'walletContext').mockResolvedValue({
+      config: getDemoConfig(),
+      actions: {} as never,
+      signer: {} as never,
+      wallet: {
+        address: '0xabc',
+        borrow: {
+          withdrawCollateral,
+          openPosition: async () => null,
+          closePosition: async () => null,
+          depositCollateral: async () => null,
+          repay: async () => null,
+        },
+        has: (n: string) => n === 'borrow',
+      } as never,
+    })
+  }
+
+  it('wraps --amount in { amount }', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xwithdraw'))
+    })
+    await runWalletBorrowWithdrawCollateral({
+      market: 'demo-dusdc-op',
+      amount: '0.5',
+    })
+    const call = captured[0] as { amount: { amount?: number; max?: boolean } }
+    expect(call.amount).toEqual({ amount: 0.5 })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.action).toBe('withdrawCollateral')
+    expect(body.collateralAmount).toBe(0.5)
+  })
+
+  it('forwards { max: true } when --max is set', async () => {
+    const captured: unknown[] = []
+    mockWallet(async (params) => {
+      captured.push(params)
+      return wrap(successReceipt('0xwithdraw'))
+    })
+    await runWalletBorrowWithdrawCollateral({
+      market: 'demo-dusdc-op',
+      max: true,
+    })
+    const call = captured[0] as { amount: { amount?: number; max?: boolean } }
+    expect(call.amount).toEqual({ max: true })
+    const body = JSON.parse(String(writeSpy.mock.calls[0]?.[0]))
+    expect(body.collateralAmount).toBe('max')
+  })
+
+  it('rejects --amount + --max together with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowWithdrawCollateral({
+        market: 'demo-dusdc-op',
+        amount: '1',
+        max: true,
+      })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/not both/)
+    }
+  })
+
+  it('rejects neither --amount nor --max with CliError(validation)', async () => {
+    mockWallet(async () => wrap(successReceipt('0x')))
+    try {
+      await runWalletBorrowWithdrawCollateral({ market: 'demo-dusdc-op' })
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/required/)
+    }
+  })
+})

--- a/packages/cli/src/commands/actions/borrow/index.ts
+++ b/packages/cli/src/commands/actions/borrow/index.ts
@@ -1,0 +1,75 @@
+import { Command } from 'commander'
+
+import { runBorrowMarket } from '@/commands/actions/borrow/market.js'
+import { runBorrowMarkets } from '@/commands/actions/borrow/markets.js'
+import { runBorrowPosition } from '@/commands/actions/borrow/position.js'
+import { loadConfig } from '@/config/loadConfig.js'
+import { configuredAssets } from '@/resolvers/assets.js'
+import { CHAIN_EXAMPLES } from '@/resolvers/chains.js'
+
+/**
+ * @description Builds the root `borrow` subcommand tree. Children read borrow data with no signer; wallet-scoped operations live under `wallet borrow`. Provider routing happens inside the SDK based on the resolved market.
+ * @returns Commander `Command` configured with `markets`, `market`, and `position`.
+ */
+export function borrowCommand(): Command {
+  const assetExample =
+    configuredAssets(loadConfig())[0]?.metadata.symbol ?? 'USDC'
+  const command = new Command('borrow').description(
+    'Read-only borrow market commands (no PRIVATE_KEY required).',
+  )
+  command
+    .command('markets')
+    .description('List all borrow markets across configured providers.')
+    .option(
+      '--collateral <symbol>',
+      `filter to markets that accept this collateral asset (e.g. ${assetExample}). Case-insensitive.`,
+    )
+    .option(
+      '--borrow-asset <symbol>',
+      'filter to markets that borrow this asset. Case-insensitive.',
+    )
+    .option(
+      '--chain <shortname>',
+      `filter to markets on one chain by shortname (e.g. ${CHAIN_EXAMPLES.shortname}); mutually exclusive with --chain-id`,
+    )
+    .option(
+      '--chain-id <id>',
+      `filter to markets on one chain by numeric id (e.g. ${CHAIN_EXAMPLES.chainId}); mutually exclusive with --chain`,
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions borrow markets --collateral USDC_DEMO --chain base-sepolia',
+    )
+    .action(runBorrowMarkets)
+  command
+    .command('market')
+    .description('Inspect one borrow market by name.')
+    .requiredOption(
+      '--market <name>',
+      'market name from the config allowlist (e.g. "Demo dUSDC / OP", "demo-dusdc-op")',
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions borrow market --market demo-dusdc-op',
+    )
+    .action(runBorrowMarket)
+  command
+    .command('position')
+    .description(
+      "Inspect any wallet's borrow position on a configured market (read-only, requires --wallet).",
+    )
+    .requiredOption(
+      '--market <name>',
+      'market name from the config allowlist (e.g. "Demo dUSDC / OP", "demo-dusdc-op")',
+    )
+    .requiredOption(
+      '--wallet <address>',
+      '0x-prefixed 20-byte address to inspect; checksummed by the CLI before dispatch',
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions borrow position --market demo-dusdc-op --wallet 0xabc...',
+    )
+    .action(runBorrowPosition)
+  return command
+}

--- a/packages/cli/src/commands/actions/borrow/market.ts
+++ b/packages/cli/src/commands/actions/borrow/market.ts
@@ -1,0 +1,26 @@
+import { baseContext } from '@/context/baseContext.js'
+import { rethrowAsCliError } from '@/output/errors.js'
+import { printOutput } from '@/output/printOutput.js'
+import {
+  configuredBorrowMarkets,
+  resolveBorrowMarket,
+} from '@/resolvers/borrowMarkets.js'
+
+/**
+ * @description Handler for `actions borrow market --market <name>`. Resolves the market name through the config allowlist and calls `actions.borrow.getMarket(market)` (the full `BorrowMarketConfig` is structurally a `BorrowMarketId`, so passing the resolved config carries the `kind` discriminant without rebuilding a literal). Read-only, no signer needed.
+ */
+export async function runBorrowMarket(flags: {
+  market: string
+}): Promise<void> {
+  const { actions, config } = baseContext()
+  const market = resolveBorrowMarket(
+    flags.market,
+    configuredBorrowMarkets(config),
+  )
+  try {
+    const result = await actions.borrow.getMarket(market)
+    printOutput('borrowMarket', result)
+  } catch (err) {
+    rethrowAsCliError(err)
+  }
+}

--- a/packages/cli/src/commands/actions/borrow/markets.ts
+++ b/packages/cli/src/commands/actions/borrow/markets.ts
@@ -1,0 +1,50 @@
+import { baseContext } from '@/context/baseContext.js'
+import { CliError, rethrowAsCliError } from '@/output/errors.js'
+import { printOutput } from '@/output/printOutput.js'
+import { configuredAssets, resolveAsset } from '@/resolvers/assets.js'
+import { type ChainFlags, resolveChainFlags } from '@/resolvers/chains.js'
+
+export interface BorrowMarketsFlags extends ChainFlags {
+  collateral?: string
+  borrowAsset?: string
+}
+
+/**
+ * @description Handler for `actions borrow markets`. Aggregates `getMarkets()` across every configured borrow provider (currently Morpho Blue). Supports `--collateral`, `--borrow-asset`, and `--chain` / `--chain-id` filters that flow through to the SDK's `GetBorrowMarketsParams`. Read-only, no signer needed. Errors surface through `rethrowAsCliError`, which maps SDK `ActionsError` subclasses to `validation` / `config` envelopes and unrecognised throws to retryable `network`.
+ * @param flags - Commander-parsed options; all filters are optional.
+ * @returns Promise that resolves once stdout has been written.
+ */
+export async function runBorrowMarkets(
+  flags: BorrowMarketsFlags = {},
+): Promise<void> {
+  const { actions, config } = baseContext()
+  const allow = configuredAssets(config)
+  const collateralAsset = flags.collateral
+    ? resolveAsset(flags.collateral, allow)
+    : undefined
+  const borrowAsset = flags.borrowAsset
+    ? resolveAsset(flags.borrowAsset, allow)
+    : undefined
+  const chainIds = resolveChainFlags(
+    flags,
+    config.chains.map((c) => c.chainId),
+  )
+  if (chainIds && chainIds.length > 1) {
+    throw new CliError(
+      'validation',
+      'borrow markets accepts a single chain (the SDK filter is single-valued)',
+      { chainIds },
+    )
+  }
+  const chainId = chainIds?.[0]
+  try {
+    const markets = await actions.borrow.getMarkets({
+      collateralAsset,
+      borrowAsset,
+      chainId,
+    })
+    printOutput('borrowMarkets', markets)
+  } catch (err) {
+    rethrowAsCliError(err)
+  }
+}

--- a/packages/cli/src/commands/actions/borrow/position.ts
+++ b/packages/cli/src/commands/actions/borrow/position.ts
@@ -1,0 +1,45 @@
+import { getAddress, isAddress } from 'viem'
+
+import { baseContext } from '@/context/baseContext.js'
+import { CliError, rethrowAsCliError } from '@/output/errors.js'
+import { printOutput } from '@/output/printOutput.js'
+import {
+  configuredBorrowMarkets,
+  resolveBorrowMarket,
+} from '@/resolvers/borrowMarkets.js'
+
+export interface BorrowPositionFlags {
+  market: string
+  wallet: string
+}
+
+/**
+ * @description Handler for `actions borrow position --market <name> --wallet <address>`. Lets an operator inspect any wallet's borrow position without needing `PRIVATE_KEY`. Validates the address with viem's `isAddress` and forwards the checksummed form to the SDK so case-only typos surface as `validation` rather than a downstream RPC mismatch. Unlike lend, the SDK exposes `getPosition` on the base namespace and requires an explicit `walletAddress`.
+ * @param flags - Commander-parsed options.
+ */
+export async function runBorrowPosition(
+  flags: BorrowPositionFlags,
+): Promise<void> {
+  const { actions, config } = baseContext()
+  const market = resolveBorrowMarket(
+    flags.market,
+    configuredBorrowMarkets(config),
+  )
+  if (!isAddress(flags.wallet)) {
+    throw new CliError(
+      'validation',
+      `Invalid --wallet: ${flags.wallet} (expected a 0x-prefixed 20-byte address)`,
+      { wallet: flags.wallet },
+    )
+  }
+  const walletAddress = getAddress(flags.wallet)
+  try {
+    const position = await actions.borrow.getPosition({
+      marketId: market,
+      walletAddress,
+    })
+    printOutput('borrowPosition', position)
+  } catch (err) {
+    rethrowAsCliError(err)
+  }
+}

--- a/packages/cli/src/commands/actions/swap/util.ts
+++ b/packages/cli/src/commands/actions/swap/util.ts
@@ -1,6 +1,4 @@
 import {
-  APPROVAL_MODES,
-  type ApprovalMode,
   type Asset,
   type SupportedChainId,
   SWAP_PROVIDER_NAMES,
@@ -12,6 +10,7 @@ import { CliError } from '@/output/errors.js'
 import { resolveAsset } from '@/resolvers/assets.js'
 import { resolveChain } from '@/resolvers/chains.js'
 import { parseAmount } from '@/utils/parseAmount.js'
+import { parseApprovalMode } from '@/utils/parseApprovalMode.js'
 import { parseSlippage } from '@/utils/parseSlippage.js'
 
 /**
@@ -92,20 +91,6 @@ export type WalletExecuteFlags = QuoteFlags & {
   approvalMode?: string
   recipient?: string
   deadline?: string
-}
-
-export function parseApprovalMode(
-  raw: string | undefined,
-): ApprovalMode | undefined {
-  if (raw === undefined) return undefined
-  if ((APPROVAL_MODES as readonly string[]).includes(raw)) {
-    return raw as ApprovalMode
-  }
-  throw new CliError(
-    'validation',
-    `Invalid --approval-mode: ${raw} (expected exact or max)`,
-    { approvalMode: raw },
-  )
 }
 
 /**

--- a/packages/cli/src/commands/wallet/borrow/close.ts
+++ b/packages/cli/src/commands/wallet/borrow/close.ts
@@ -1,0 +1,101 @@
+import type { AmountOrMax } from '@eth-optimism/actions-sdk'
+
+import { CliError } from '@/output/errors.js'
+import { parseAmount } from '@/utils/parseAmount.js'
+
+import { runBorrowAction } from './runBorrowAction.js'
+
+/**
+ * @description Loose argv shape for `actions wallet borrow close`. Commander hands the handler a plain object with no per-flag mutual exclusivity enforced, so the field types here mirror what commander produces and the runtime guards in `runWalletBorrowClose` translate that into the strict `AmountOrMax` per leg.
+ */
+export interface BorrowCloseFlags {
+  market: string
+  borrowAmount?: string
+  borrowMax?: boolean
+  collateralAmount?: string
+  collateralMax?: boolean
+}
+
+/**
+ * @description Handler for `actions wallet borrow close --market <name> [--borrow-amount <n> | --borrow-max] [--collateral-amount <n> | --collateral-max]`. The borrow leg is required by the SDK type (`AmountOrMax`); the collateral leg is optional. Each leg is internally xor (you may pass at most one of `--<leg>-amount` / `--<leg>-max`). `--*-max` resolves to the SDK's full-balance path at dispatch time, avoiding dust left behind by interest accrual.
+ * @param flags - Commander-parsed options.
+ * @throws `CliError` with code `validation` when both `*-amount` and `*-max` are set on the same leg, or when the borrow leg is missing.
+ */
+export async function runWalletBorrowClose(
+  flags: BorrowCloseFlags,
+): Promise<void> {
+  const borrowAmount = resolveLeg(
+    'borrow',
+    flags.borrowAmount,
+    flags.borrowMax === true,
+    true,
+  )
+  const collateralAmount = resolveLeg(
+    'collateral',
+    flags.collateralAmount,
+    flags.collateralMax === true,
+    false,
+  )
+  await runBorrowAction({
+    action: 'close',
+    marketName: flags.market,
+    buildAndDispatch: async (wallet, market) =>
+      wallet.borrow.closePosition({
+        market,
+        borrowAmount,
+        collateralAmount,
+      }),
+    envelopeAmounts: {
+      borrowAmount: envelopeFor(borrowAmount),
+      collateralAmount: envelopeFor(collateralAmount),
+    },
+  })
+}
+
+function resolveLeg(
+  leg: 'borrow' | 'collateral',
+  raw: string | undefined,
+  isMax: boolean,
+  required: true,
+): AmountOrMax
+function resolveLeg(
+  leg: 'borrow' | 'collateral',
+  raw: string | undefined,
+  isMax: boolean,
+  required: false,
+): AmountOrMax | undefined
+function resolveLeg(
+  leg: 'borrow' | 'collateral',
+  raw: string | undefined,
+  isMax: boolean,
+  required: boolean,
+): AmountOrMax | undefined {
+  const amountFlag = `--${leg}-amount`
+  const maxFlag = `--${leg}-max`
+  if (raw !== undefined && isMax) {
+    throw new CliError(
+      'validation',
+      `Pass either ${amountFlag} or ${maxFlag}, not both`,
+      { leg, [amountFlag.slice(2)]: raw, [maxFlag.slice(2)]: true },
+    )
+  }
+  if (isMax) return { max: true }
+  if (raw !== undefined) return { amount: parseAmount(raw, amountFlag) }
+  if (required) {
+    throw new CliError(
+      'validation',
+      `Either ${amountFlag} or ${maxFlag} is required`,
+      { leg },
+    )
+  }
+  return undefined
+}
+
+function envelopeFor(
+  value: AmountOrMax | undefined,
+): number | 'max' | undefined {
+  if (value === undefined) return undefined
+  if ('max' in value) return 'max'
+  if ('amount' in value) return value.amount
+  return undefined
+}

--- a/packages/cli/src/commands/wallet/borrow/close.ts
+++ b/packages/cli/src/commands/wallet/borrow/close.ts
@@ -1,9 +1,8 @@
-import type { AmountOrMax } from '@eth-optimism/actions-sdk'
-
-import { CliError } from '@/output/errors.js'
-import { parseAmount } from '@/utils/parseAmount.js'
-
-import { runBorrowAction } from './runBorrowAction.js'
+import {
+  amountOrMaxToEnvelope,
+  resolveAmountOrMax,
+  runBorrowAction,
+} from './runBorrowAction.js'
 
 /**
  * @description Loose argv shape for `actions wallet borrow close`. Commander hands the handler a plain object with no per-flag mutual exclusivity enforced, so the field types here mirror what commander produces and the runtime guards in `runWalletBorrowClose` translate that into the strict `AmountOrMax` per leg.
@@ -24,16 +23,22 @@ export interface BorrowCloseFlags {
 export async function runWalletBorrowClose(
   flags: BorrowCloseFlags,
 ): Promise<void> {
-  const borrowAmount = resolveLeg(
-    'borrow',
-    flags.borrowAmount,
-    flags.borrowMax === true,
+  const borrowAmount = resolveAmountOrMax(
+    {
+      amountFlag: '--borrow-amount',
+      maxFlag: '--borrow-max',
+      raw: flags.borrowAmount,
+      isMax: flags.borrowMax === true,
+    },
     true,
   )
-  const collateralAmount = resolveLeg(
-    'collateral',
-    flags.collateralAmount,
-    flags.collateralMax === true,
+  const collateralAmount = resolveAmountOrMax(
+    {
+      amountFlag: '--collateral-amount',
+      maxFlag: '--collateral-max',
+      raw: flags.collateralAmount,
+      isMax: flags.collateralMax === true,
+    },
     false,
   )
   await runBorrowAction({
@@ -46,56 +51,8 @@ export async function runWalletBorrowClose(
         collateralAmount,
       }),
     envelopeAmounts: {
-      borrowAmount: envelopeFor(borrowAmount),
-      collateralAmount: envelopeFor(collateralAmount),
+      borrowAmount: amountOrMaxToEnvelope(borrowAmount),
+      collateralAmount: amountOrMaxToEnvelope(collateralAmount),
     },
   })
-}
-
-function resolveLeg(
-  leg: 'borrow' | 'collateral',
-  raw: string | undefined,
-  isMax: boolean,
-  required: true,
-): AmountOrMax
-function resolveLeg(
-  leg: 'borrow' | 'collateral',
-  raw: string | undefined,
-  isMax: boolean,
-  required: false,
-): AmountOrMax | undefined
-function resolveLeg(
-  leg: 'borrow' | 'collateral',
-  raw: string | undefined,
-  isMax: boolean,
-  required: boolean,
-): AmountOrMax | undefined {
-  const amountFlag = `--${leg}-amount`
-  const maxFlag = `--${leg}-max`
-  if (raw !== undefined && isMax) {
-    throw new CliError(
-      'validation',
-      `Pass either ${amountFlag} or ${maxFlag}, not both`,
-      { leg, [amountFlag.slice(2)]: raw, [maxFlag.slice(2)]: true },
-    )
-  }
-  if (isMax) return { max: true }
-  if (raw !== undefined) return { amount: parseAmount(raw, amountFlag) }
-  if (required) {
-    throw new CliError(
-      'validation',
-      `Either ${amountFlag} or ${maxFlag} is required`,
-      { leg },
-    )
-  }
-  return undefined
-}
-
-function envelopeFor(
-  value: AmountOrMax | undefined,
-): number | 'max' | undefined {
-  if (value === undefined) return undefined
-  if ('max' in value) return 'max'
-  if ('amount' in value) return value.amount
-  return undefined
 }

--- a/packages/cli/src/commands/wallet/borrow/deposit-collateral.ts
+++ b/packages/cli/src/commands/wallet/borrow/deposit-collateral.ts
@@ -1,6 +1,7 @@
 import { parseAmount } from '@/utils/parseAmount.js'
+import { parseApprovalMode } from '@/utils/parseApprovalMode.js'
 
-import { parseApprovalMode, runBorrowAction } from './runBorrowAction.js'
+import { runBorrowAction } from './runBorrowAction.js'
 
 export interface BorrowDepositCollateralFlags {
   market: string

--- a/packages/cli/src/commands/wallet/borrow/deposit-collateral.ts
+++ b/packages/cli/src/commands/wallet/borrow/deposit-collateral.ts
@@ -1,0 +1,32 @@
+import { parseAmount } from '@/utils/parseAmount.js'
+
+import { parseApprovalMode, runBorrowAction } from './runBorrowAction.js'
+
+export interface BorrowDepositCollateralFlags {
+  market: string
+  amount: string
+  /** Optional override of the wallet-level approval-amount strategy. */
+  approvalMode?: string
+}
+
+/**
+ * @description Handler for `actions wallet borrow deposit-collateral --market <name> --amount <n> [--approval-mode <exact|max>]`. Tops up collateral on an existing borrow position without changing the debt side. No `--max` flag: the SDK accepts only the strict `Amount` shape because depositing requires a finite amount the wallet currently holds (a "max balance" path would race the wallet's live token balance against pending state).
+ * @param flags - Commander-parsed required options.
+ */
+export async function runWalletBorrowDepositCollateral(
+  flags: BorrowDepositCollateralFlags,
+): Promise<void> {
+  const amount = parseAmount(flags.amount, '--amount')
+  const approvalMode = parseApprovalMode(flags.approvalMode)
+  await runBorrowAction({
+    action: 'depositCollateral',
+    marketName: flags.market,
+    buildAndDispatch: async (wallet, market) =>
+      wallet.borrow.depositCollateral({
+        market,
+        amount: { amount },
+        approvalMode,
+      }),
+    envelopeAmounts: { collateralAmount: amount },
+  })
+}

--- a/packages/cli/src/commands/wallet/borrow/index.ts
+++ b/packages/cli/src/commands/wallet/borrow/index.ts
@@ -1,0 +1,137 @@
+import { APPROVAL_MODES } from '@eth-optimism/actions-sdk'
+import { Command } from 'commander'
+
+import { runWalletBorrowClose } from '@/commands/wallet/borrow/close.js'
+import { runWalletBorrowDepositCollateral } from '@/commands/wallet/borrow/deposit-collateral.js'
+import { runWalletBorrowOpen } from '@/commands/wallet/borrow/open.js'
+import { runWalletBorrowPosition } from '@/commands/wallet/borrow/position.js'
+import { runWalletBorrowRepay } from '@/commands/wallet/borrow/repay.js'
+import { runWalletBorrowWithdrawCollateral } from '@/commands/wallet/borrow/withdraw-collateral.js'
+
+const MARKET_DESC =
+  'market name from the config allowlist (e.g. "Demo dUSDC / OP", "demo-dusdc-op")'
+
+/**
+ * @description Builds the `wallet borrow` subcommand tree. Children resolve their market through the config allowlist and dispatch to the matching `wallet.borrow.*` method. Read-only `markets` / `market` / `position` aliases live on the root `actions borrow` tree so they don't force `PRIVATE_KEY` on operators who only want to read.
+ * @returns Commander `Command` configured with `open`, `close`, `deposit-collateral`, `withdraw-collateral`, `repay`, and `position`.
+ */
+export function walletBorrowCommand(): Command {
+  const command = new Command('borrow').description(
+    'Open, close, adjust, and inspect borrow positions on configured markets.',
+  )
+  command
+    .command('open')
+    .description('Borrow against collateral on a borrow market.')
+    .requiredOption('--market <name>', MARKET_DESC)
+    .requiredOption(
+      '--borrow-amount <n>',
+      'amount to borrow in human-readable units (e.g. 100 for 100 OP)',
+    )
+    .option(
+      '--collateral-amount <n>',
+      'collateral to deposit alongside the borrow; omit to borrow against previously deposited collateral',
+    )
+    .option(
+      `--approval-mode <${APPROVAL_MODES.join('|')}>`,
+      'ERC-20 approval strategy: "exact" approves only this call (default, gas-heavier on repeat); "max" approves max-uint to amortise across future top-ups',
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions wallet borrow open --market demo-dusdc-op --borrow-amount 1 --collateral-amount 2',
+    )
+    .action(runWalletBorrowOpen)
+  command
+    .command('close')
+    .description(
+      'Unwind a borrow position: repay debt and optionally withdraw collateral.',
+    )
+    .requiredOption('--market <name>', MARKET_DESC)
+    .option(
+      '--borrow-amount <n>',
+      'debt to repay in human-readable units; mutually exclusive with --borrow-max',
+    )
+    .option(
+      '--borrow-max',
+      "repay the wallet's entire debt in this market (resolves on-chain at dispatch time to avoid interest-accrual dust); mutually exclusive with --borrow-amount",
+    )
+    .option(
+      '--collateral-amount <n>',
+      'collateral to withdraw in human-readable units; omit to leave collateral on the position; mutually exclusive with --collateral-max',
+    )
+    .option(
+      '--collateral-max',
+      "withdraw the wallet's entire collateral in this market; mutually exclusive with --collateral-amount",
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions wallet borrow close --market demo-dusdc-op --borrow-max --collateral-max',
+    )
+    .action(runWalletBorrowClose)
+  command
+    .command('deposit-collateral')
+    .description(
+      'Deposit additional collateral without changing the debt side.',
+    )
+    .requiredOption('--market <name>', MARKET_DESC)
+    .requiredOption(
+      '--amount <n>',
+      'collateral to deposit in human-readable units (e.g. 5 for 5 USDC)',
+    )
+    .option(
+      `--approval-mode <${APPROVAL_MODES.join('|')}>`,
+      'ERC-20 approval strategy: "exact" approves only this call (default); "max" approves max-uint to amortise across future deposits',
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions wallet borrow deposit-collateral --market demo-dusdc-op --amount 5',
+    )
+    .action(runWalletBorrowDepositCollateral)
+  command
+    .command('withdraw-collateral')
+    .description('Withdraw collateral without touching the debt side.')
+    .requiredOption('--market <name>', MARKET_DESC)
+    .option(
+      '--amount <n>',
+      'collateral to withdraw in human-readable units; mutually exclusive with --max',
+    )
+    .option(
+      '--max',
+      "withdraw the wallet's entire collateral (resolves on-chain at dispatch time); mutually exclusive with --amount",
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions wallet borrow withdraw-collateral --market demo-dusdc-op --amount 1',
+    )
+    .action(runWalletBorrowWithdrawCollateral)
+  command
+    .command('repay')
+    .description('Repay outstanding debt without touching collateral.')
+    .requiredOption('--market <name>', MARKET_DESC)
+    .option(
+      '--amount <n>',
+      'debt to repay in human-readable units; mutually exclusive with --max',
+    )
+    .option(
+      '--max',
+      'repay the entire outstanding debt (resolves on-chain at dispatch time, avoiding interest-accrual dust); mutually exclusive with --amount',
+    )
+    .option(
+      `--approval-mode <${APPROVAL_MODES.join('|')}>`,
+      'ERC-20 approval strategy for the repay token: "exact" approves only this call; "max" amortises across future repays',
+    )
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions wallet borrow repay --market demo-dusdc-op --max',
+    )
+    .action(runWalletBorrowRepay)
+  command
+    .command('position')
+    .description('Inspect the current borrow position for the wallet.')
+    .requiredOption('--market <name>', MARKET_DESC)
+    .addHelpText(
+      'after',
+      '\nExample:\n  actions wallet borrow position --market demo-dusdc-op',
+    )
+    .action(runWalletBorrowPosition)
+  return command
+}

--- a/packages/cli/src/commands/wallet/borrow/open.ts
+++ b/packages/cli/src/commands/wallet/borrow/open.ts
@@ -1,6 +1,7 @@
 import { parseAmount } from '@/utils/parseAmount.js'
+import { parseApprovalMode } from '@/utils/parseApprovalMode.js'
 
-import { parseApprovalMode, runBorrowAction } from './runBorrowAction.js'
+import { runBorrowAction } from './runBorrowAction.js'
 
 export interface BorrowOpenFlags {
   market: string

--- a/packages/cli/src/commands/wallet/borrow/open.ts
+++ b/packages/cli/src/commands/wallet/borrow/open.ts
@@ -1,0 +1,44 @@
+import { parseAmount } from '@/utils/parseAmount.js'
+
+import { parseApprovalMode, runBorrowAction } from './runBorrowAction.js'
+
+export interface BorrowOpenFlags {
+  market: string
+  borrowAmount: string
+  collateralAmount?: string
+  /** Optional override of the wallet-level approval-amount strategy. */
+  approvalMode?: string
+}
+
+/**
+ * @description Handler for `actions wallet borrow open --market <name> --borrow-amount <n> [--collateral-amount <n>] [--approval-mode <exact|max>]`. Borrowing without simultaneously depositing collateral is supported (`--collateral-amount` omitted) when the caller already has collateral on the position. No `--max` flag here: the open path only accepts the strict `Amount` shape on either leg.
+ * @param flags - Commander-parsed required options.
+ */
+export async function runWalletBorrowOpen(
+  flags: BorrowOpenFlags,
+): Promise<void> {
+  const borrowAmount = parseAmount(flags.borrowAmount, '--borrow-amount')
+  const collateralAmount =
+    flags.collateralAmount !== undefined
+      ? parseAmount(flags.collateralAmount, '--collateral-amount')
+      : undefined
+  const approvalMode = parseApprovalMode(flags.approvalMode)
+  await runBorrowAction({
+    action: 'open',
+    marketName: flags.market,
+    buildAndDispatch: async (wallet, market) =>
+      wallet.borrow.openPosition({
+        market,
+        borrowAmount: { amount: borrowAmount },
+        collateralAmount:
+          collateralAmount !== undefined
+            ? { amount: collateralAmount }
+            : undefined,
+        approvalMode,
+      }),
+    envelopeAmounts: {
+      borrowAmount,
+      collateralAmount,
+    },
+  })
+}

--- a/packages/cli/src/commands/wallet/borrow/position.ts
+++ b/packages/cli/src/commands/wallet/borrow/position.ts
@@ -1,0 +1,33 @@
+import { walletContext } from '@/context/walletContext.js'
+import { rethrowAsCliError } from '@/output/errors.js'
+import { printOutput } from '@/output/printOutput.js'
+import {
+  configuredBorrowMarkets,
+  resolveBorrowMarket,
+} from '@/resolvers/borrowMarkets.js'
+
+import { requireBorrowCapability } from './requireBorrowCapability.js'
+
+/**
+ * @description Handler for `actions wallet borrow position --market <name>`. Resolves the market through the config allowlist and reads the connected wallet's position. Unlike `actions borrow position`, no `--wallet` flag is required: the wallet's address comes from the loaded `PRIVATE_KEY`. The SDK's `getPosition` lives on the base namespace and takes both `marketId` and `walletAddress`, so the handler still has to forward them both.
+ * @param flags - Commander-parsed required options.
+ */
+export async function runWalletBorrowPosition(flags: {
+  market: string
+}): Promise<void> {
+  const { wallet, actions, config } = await walletContext()
+  requireBorrowCapability(wallet)
+  const market = resolveBorrowMarket(
+    flags.market,
+    configuredBorrowMarkets(config),
+  )
+  try {
+    const position = await actions.borrow.getPosition({
+      marketId: market,
+      walletAddress: wallet.address,
+    })
+    printOutput('borrowPosition', position)
+  } catch (err) {
+    rethrowAsCliError(err)
+  }
+}

--- a/packages/cli/src/commands/wallet/borrow/repay.ts
+++ b/packages/cli/src/commands/wallet/borrow/repay.ts
@@ -1,7 +1,9 @@
-import { CliError } from '@/output/errors.js'
-import { parseAmount } from '@/utils/parseAmount.js'
-
-import { parseApprovalMode, runBorrowAction } from './runBorrowAction.js'
+import {
+  amountOrMaxToEnvelope,
+  parseApprovalMode,
+  resolveAmountOrMax,
+  runBorrowAction,
+} from './runBorrowAction.js'
 
 export interface BorrowRepayFlags {
   market: string
@@ -19,28 +21,21 @@ export interface BorrowRepayFlags {
 export async function runWalletBorrowRepay(
   flags: BorrowRepayFlags,
 ): Promise<void> {
-  const isMax = flags.max === true
-  if (isMax && flags.amount !== undefined) {
-    throw new CliError(
-      'validation',
-      'Pass either --amount or --max, not both',
-      { amount: flags.amount, max: true },
-    )
-  }
-  if (!isMax && flags.amount === undefined) {
-    throw new CliError('validation', 'Either --amount or --max is required')
-  }
-  const amount = isMax ? undefined : parseAmount(flags.amount as string)
+  const amount = resolveAmountOrMax(
+    {
+      amountFlag: '--amount',
+      maxFlag: '--max',
+      raw: flags.amount,
+      isMax: flags.max === true,
+    },
+    true,
+  )
   const approvalMode = parseApprovalMode(flags.approvalMode)
   await runBorrowAction({
     action: 'repay',
     marketName: flags.market,
     buildAndDispatch: async (wallet, market) =>
-      wallet.borrow.repay({
-        market,
-        amount: isMax ? { max: true } : { amount: amount as number },
-        approvalMode,
-      }),
-    envelopeAmounts: { borrowAmount: isMax ? 'max' : amount },
+      wallet.borrow.repay({ market, amount, approvalMode }),
+    envelopeAmounts: { borrowAmount: amountOrMaxToEnvelope(amount) },
   })
 }

--- a/packages/cli/src/commands/wallet/borrow/repay.ts
+++ b/packages/cli/src/commands/wallet/borrow/repay.ts
@@ -1,0 +1,46 @@
+import { CliError } from '@/output/errors.js'
+import { parseAmount } from '@/utils/parseAmount.js'
+
+import { parseApprovalMode, runBorrowAction } from './runBorrowAction.js'
+
+export interface BorrowRepayFlags {
+  market: string
+  amount?: string
+  max?: boolean
+  /** Optional override of the wallet-level approval-amount strategy. */
+  approvalMode?: string
+}
+
+/**
+ * @description Handler for `actions wallet borrow repay --market <name> (--amount <n> | --max) [--approval-mode <exact|max>]`. Repays debt without touching collateral. `--max` resolves to the wallet's outstanding debt at dispatch time, avoiding the dust that strict-amount repays leave behind when interest accrues between quote and submit.
+ * @param flags - Commander-parsed options.
+ * @throws `CliError` with code `validation` when both `--amount` and `--max` are set or when neither is.
+ */
+export async function runWalletBorrowRepay(
+  flags: BorrowRepayFlags,
+): Promise<void> {
+  const isMax = flags.max === true
+  if (isMax && flags.amount !== undefined) {
+    throw new CliError(
+      'validation',
+      'Pass either --amount or --max, not both',
+      { amount: flags.amount, max: true },
+    )
+  }
+  if (!isMax && flags.amount === undefined) {
+    throw new CliError('validation', 'Either --amount or --max is required')
+  }
+  const amount = isMax ? undefined : parseAmount(flags.amount as string)
+  const approvalMode = parseApprovalMode(flags.approvalMode)
+  await runBorrowAction({
+    action: 'repay',
+    marketName: flags.market,
+    buildAndDispatch: async (wallet, market) =>
+      wallet.borrow.repay({
+        market,
+        amount: isMax ? { max: true } : { amount: amount as number },
+        approvalMode,
+      }),
+    envelopeAmounts: { borrowAmount: isMax ? 'max' : amount },
+  })
+}

--- a/packages/cli/src/commands/wallet/borrow/repay.ts
+++ b/packages/cli/src/commands/wallet/borrow/repay.ts
@@ -1,6 +1,7 @@
+import { parseApprovalMode } from '@/utils/parseApprovalMode.js'
+
 import {
   amountOrMaxToEnvelope,
-  parseApprovalMode,
   resolveAmountOrMax,
   runBorrowAction,
 } from './runBorrowAction.js'

--- a/packages/cli/src/commands/wallet/borrow/requireBorrowCapability.ts
+++ b/packages/cli/src/commands/wallet/borrow/requireBorrowCapability.ts
@@ -1,0 +1,19 @@
+import type { Wallet } from '@eth-optimism/actions-sdk'
+
+import { CliError } from '@/output/errors.js'
+
+/**
+ * @description Asserts that a `Wallet` has the borrow namespace configured. Defers the runtime check to `Wallet.has('borrow')` and narrows `wallet.borrow` to non-null on the caller side so each handler can reach `wallet.borrow.openPosition` etc. without re-checking. Throws `CliError('config')` when no borrow providers are configured (`ActionsConfig.borrow` was omitted or empty).
+ * @param wallet - Wallet instance from `walletContext()`.
+ * @throws `CliError` with code `config` when `wallet.borrow` is undefined.
+ */
+export function requireBorrowCapability<W extends Wallet>(
+  wallet: W,
+): asserts wallet is W & { borrow: NonNullable<W['borrow']> } {
+  if (!wallet.has('borrow')) {
+    throw new CliError(
+      'config',
+      'Borrowing is not configured (no providers in config.borrow)',
+    )
+  }
+}

--- a/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
+++ b/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
@@ -1,5 +1,4 @@
 import {
-  type Amount,
   type AmountOrMax,
   APPROVAL_MODES,
   type ApprovalMode,
@@ -26,32 +25,67 @@ import { requireBorrowCapability } from './requireBorrowCapability.js'
 
 type WalletWithBorrow = Wallet & { borrow: NonNullable<Wallet['borrow']> }
 
-/**
- * @description Wraps a `parseAmount(raw)` result in the `{ amount }` discriminant of the SDK's `Amount` union. Borrow params don't accept bare numbers; #379 conventions require either `{ amount }` (human-readable) or `{ amountRaw }` (wei). The CLI always takes a human-readable amount, so we never produce the raw variant.
- * @param raw - The CLI argv value as a string.
- * @param flag - Flag label surfaced in `CliError` messages (e.g. `--borrow-amount`).
- * @returns An `Amount` of the form `{ amount: number }`.
- * @throws `CliError` with code `validation` when the value is not a positive plain decimal.
- */
-export function toAmount(raw: string, flag = '--amount'): Amount {
-  return { amount: parseAmount(raw, flag) }
+interface ResolveAmountOrMaxArgs {
+  /** Flag label for the amount input, e.g. `--amount` or `--borrow-amount`. */
+  amountFlag: string
+  /** Flag label for the full-balance input, e.g. `--max` or `--borrow-max`. */
+  maxFlag: string
+  /** Raw CLI value supplied for `amountFlag`, if any. */
+  raw: string | undefined
+  /** Whether the user passed `maxFlag`. */
+  isMax: boolean
 }
 
 /**
- * @description Builds an `AmountOrMax` from the mutually-exclusive amount/max flag pair. Returns `{ max: true }` when `isMax` is set, otherwise wraps the parsed amount via `toAmount`. Callers are responsible for enforcing the xor at the CLI surface; this helper just maps the resolved booleans to the right discriminant.
- * @param raw - The CLI argv value, if any.
- * @param isMax - Whether the user opted into the SDK's full-balance path.
- * @param flag - Flag label surfaced in `CliError` messages (e.g. `--borrow-amount`).
- * @returns An `AmountOrMax` value.
- * @throws `CliError` with code `validation` when `isMax` is false and `raw` is not a positive plain decimal.
+ * @description Resolves the mutually-exclusive `<amount>` / `<max>` flag pair to an `AmountOrMax`, enforcing the xor at the CLI surface. The `required: true` overload narrows the return type to `AmountOrMax`; `required: false` allows the absence-of-both case and widens to `AmountOrMax | undefined`. Used by every borrow write verb that accepts `--max` on at least one leg (`close`, `withdraw-collateral`, `repay`). Flag labels are passed in (rather than constructed from a leg prefix) so single-leg callers can use `--amount` / `--max` and `close` can use `--borrow-amount` / `--borrow-max` / `--collateral-amount` / `--collateral-max` from the same code path.
+ * @param args - Flag labels, the raw amount value, and the `isMax` boolean.
+ * @param required - When `true`, throws if neither flag is set; when `false`, returns `undefined`.
+ * @returns The resolved `AmountOrMax`, or `undefined` when the leg is optional and unset.
+ * @throws `CliError` with code `validation` when both flags are set, when the amount fails to parse, or when neither flag is set and `required` is `true`.
  */
-export function toAmountOrMax(
-  raw: string | undefined,
-  isMax: boolean,
-  flag = '--amount',
-): AmountOrMax {
+export function resolveAmountOrMax(
+  args: ResolveAmountOrMaxArgs,
+  required: true,
+): AmountOrMax
+export function resolveAmountOrMax(
+  args: ResolveAmountOrMaxArgs,
+  required: false,
+): AmountOrMax | undefined
+export function resolveAmountOrMax(
+  args: ResolveAmountOrMaxArgs,
+  required: boolean,
+): AmountOrMax | undefined {
+  const { amountFlag, maxFlag, raw, isMax } = args
+  if (raw !== undefined && isMax) {
+    throw new CliError(
+      'validation',
+      `Pass either ${amountFlag} or ${maxFlag}, not both`,
+      { [amountFlag]: raw, [maxFlag]: true },
+    )
+  }
   if (isMax) return { max: true }
-  return toAmount(raw as string, flag)
+  if (raw !== undefined) return { amount: parseAmount(raw, amountFlag) }
+  if (required) {
+    throw new CliError(
+      'validation',
+      `Either ${amountFlag} or ${maxFlag} is required`,
+    )
+  }
+  return undefined
+}
+
+/**
+ * @description Projects an `AmountOrMax` (or absent leg) into the envelope's `number | 'max'` representation. The CLI envelope speaks in decimals and the literal string `'max'`; the SDK's discriminated `{ amount } | { amountRaw } | { max }` shape never leaves the wallet method call. Used by every verb that emits `borrowAmount` / `collateralAmount` in the action envelope.
+ * @param value - The resolved leg, or `undefined` when the leg was untouched.
+ * @returns `'max'` for the full-balance path, the bare number for `{ amount }`, otherwise `undefined`. `amountRaw` is intentionally not handled (the CLI never builds it).
+ */
+export function amountOrMaxToEnvelope(
+  value: AmountOrMax | undefined,
+): number | 'max' | undefined {
+  if (value === undefined) return undefined
+  if ('max' in value) return 'max'
+  if ('amount' in value) return value.amount
+  return undefined
 }
 
 /**

--- a/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
+++ b/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
@@ -1,7 +1,5 @@
 import {
   type AmountOrMax,
-  APPROVAL_MODES,
-  type ApprovalMode,
   type BorrowAction,
   type BorrowMarketConfig,
   type BorrowReceipt,
@@ -86,26 +84,6 @@ export function amountOrMaxToEnvelope(
   if ('max' in value) return 'max'
   if ('amount' in value) return value.amount
   return undefined
-}
-
-/**
- * @description Validates `--approval-mode` against the SDK's `APPROVAL_MODES` allowlist. Returns `undefined` when the flag is omitted so the wallet's resolved default applies. Identical shape to the lend helper; deduplicated here because both lend and borrow expose the same flag with the same semantics.
- * @param raw - The argv value as a string, or `undefined`.
- * @returns The validated `ApprovalMode`, or `undefined` when unset.
- * @throws `CliError` with code `validation` when `raw` is not a recognised approval mode.
- */
-export function parseApprovalMode(
-  raw: string | undefined,
-): ApprovalMode | undefined {
-  if (raw === undefined) return undefined
-  if ((APPROVAL_MODES as readonly string[]).includes(raw)) {
-    return raw as ApprovalMode
-  }
-  throw new CliError(
-    'validation',
-    `Invalid --approval-mode: ${raw} (expected ${APPROVAL_MODES.join(' or ')})`,
-    { approvalMode: raw },
-  )
 }
 
 interface RunBorrowActionArgs {

--- a/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
+++ b/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
@@ -163,8 +163,8 @@ export async function runBorrowAction(
       },
       ...args.envelopeAmounts,
       transactions: receipts,
-      ltv: borrowReceipt.positionAfter?.ltv ?? undefined,
-      healthFactor: borrowReceipt.positionAfter?.healthFactor ?? undefined,
+      ltv: borrowReceipt.positionAfter?.ltv,
+      healthFactor: borrowReceipt.positionAfter?.healthFactor,
       liquidationPriceFormatted:
         borrowReceipt.positionAfter?.liquidationPriceFormatted,
     })

--- a/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
+++ b/packages/cli/src/commands/wallet/borrow/runBorrowAction.ts
@@ -1,0 +1,140 @@
+import {
+  type Amount,
+  type AmountOrMax,
+  APPROVAL_MODES,
+  type ApprovalMode,
+  type BorrowAction,
+  type BorrowMarketConfig,
+  type BorrowReceipt,
+  type Wallet,
+} from '@eth-optimism/actions-sdk'
+
+import { walletContext } from '@/context/walletContext.js'
+import { CliError, rethrowAsCliError } from '@/output/errors.js'
+import {
+  type BorrowEnvelopeAmounts,
+  printOutput,
+} from '@/output/printOutput.js'
+import {
+  configuredBorrowMarkets,
+  resolveBorrowMarket,
+} from '@/resolvers/borrowMarkets.js'
+import { parseAmount } from '@/utils/parseAmount.js'
+import { ensureOnchainSuccess, toReceiptArray } from '@/utils/receipts.js'
+
+import { requireBorrowCapability } from './requireBorrowCapability.js'
+
+type WalletWithBorrow = Wallet & { borrow: NonNullable<Wallet['borrow']> }
+
+/**
+ * @description Wraps a `parseAmount(raw)` result in the `{ amount }` discriminant of the SDK's `Amount` union. Borrow params don't accept bare numbers; #379 conventions require either `{ amount }` (human-readable) or `{ amountRaw }` (wei). The CLI always takes a human-readable amount, so we never produce the raw variant.
+ * @param raw - The CLI argv value as a string.
+ * @param flag - Flag label surfaced in `CliError` messages (e.g. `--borrow-amount`).
+ * @returns An `Amount` of the form `{ amount: number }`.
+ * @throws `CliError` with code `validation` when the value is not a positive plain decimal.
+ */
+export function toAmount(raw: string, flag = '--amount'): Amount {
+  return { amount: parseAmount(raw, flag) }
+}
+
+/**
+ * @description Builds an `AmountOrMax` from the mutually-exclusive amount/max flag pair. Returns `{ max: true }` when `isMax` is set, otherwise wraps the parsed amount via `toAmount`. Callers are responsible for enforcing the xor at the CLI surface; this helper just maps the resolved booleans to the right discriminant.
+ * @param raw - The CLI argv value, if any.
+ * @param isMax - Whether the user opted into the SDK's full-balance path.
+ * @param flag - Flag label surfaced in `CliError` messages (e.g. `--borrow-amount`).
+ * @returns An `AmountOrMax` value.
+ * @throws `CliError` with code `validation` when `isMax` is false and `raw` is not a positive plain decimal.
+ */
+export function toAmountOrMax(
+  raw: string | undefined,
+  isMax: boolean,
+  flag = '--amount',
+): AmountOrMax {
+  if (isMax) return { max: true }
+  return toAmount(raw as string, flag)
+}
+
+/**
+ * @description Validates `--approval-mode` against the SDK's `APPROVAL_MODES` allowlist. Returns `undefined` when the flag is omitted so the wallet's resolved default applies. Identical shape to the lend helper; deduplicated here because both lend and borrow expose the same flag with the same semantics.
+ * @param raw - The argv value as a string, or `undefined`.
+ * @returns The validated `ApprovalMode`, or `undefined` when unset.
+ * @throws `CliError` with code `validation` when `raw` is not a recognised approval mode.
+ */
+export function parseApprovalMode(
+  raw: string | undefined,
+): ApprovalMode | undefined {
+  if (raw === undefined) return undefined
+  if ((APPROVAL_MODES as readonly string[]).includes(raw)) {
+    return raw as ApprovalMode
+  }
+  throw new CliError(
+    'validation',
+    `Invalid --approval-mode: ${raw} (expected ${APPROVAL_MODES.join(' or ')})`,
+    { approvalMode: raw },
+  )
+}
+
+interface RunBorrowActionArgs {
+  /** Verb literal embedded in the emitted `borrowAction` envelope. */
+  action: BorrowAction
+  /** Raw `--market` flag value (resolved through the config allowlist). */
+  marketName: string
+  /**
+   * Builds the SDK params and runs the matching `wallet.borrow.*` method.
+   * Implementations may parse amounts and approval modes inline; this runner
+   * just provides the resolved market and the capability-narrowed wallet.
+   */
+  buildAndDispatch: (
+    wallet: WalletWithBorrow,
+    market: BorrowMarketConfig,
+  ) => Promise<BorrowReceipt>
+  /**
+   * Human-readable amounts to embed in the envelope. The receipt's wei-scale
+   * `borrowAmount` / `collateralAmount` are intentionally not emitted at this
+   * layer; the CLI surface speaks in decimals and `'max'`.
+   */
+  envelopeAmounts: BorrowEnvelopeAmounts
+}
+
+/**
+ * @description Shared backbone for the wallet-scoped borrow write verbs. Loads the wallet context (which validates `PRIVATE_KEY`), asserts the borrow capability, resolves the market through the config allowlist, runs the caller-supplied dispatcher, normalises the SDK's `BorrowReceipt.receipt` (single tx, batched tx array, or UserOp envelope) into a flat array, raises on any non-success leg, and emits a `borrowAction` envelope decorated with `positionAfter` highlights when the SDK supplies them.
+ * @param args - Verb-specific dispatcher plus envelope inputs.
+ * @returns Promise that resolves once stdout has been written.
+ * @throws `CliError` with code `config` when `PRIVATE_KEY` or `wallet.borrow` is missing; `validation` for unknown markets or bad params; `onchain` for reverts and failed receipts; retryable `network` for everything else.
+ */
+export async function runBorrowAction(
+  args: RunBorrowActionArgs,
+): Promise<void> {
+  const { wallet, config } = await walletContext()
+  requireBorrowCapability(wallet)
+  const market = resolveBorrowMarket(
+    args.marketName,
+    configuredBorrowMarkets(config),
+  )
+  try {
+    const borrowReceipt = await args.buildAndDispatch(wallet, market)
+    const receipts = toReceiptArray(borrowReceipt.receipt)
+    ensureOnchainSuccess(receipts)
+    printOutput('borrowAction', {
+      action: args.action,
+      market: {
+        name: market.name,
+        marketId: {
+          kind: market.kind,
+          marketId: market.marketId,
+          chainId: market.chainId,
+        },
+        chainId: market.chainId,
+        provider: market.borrowProvider,
+      },
+      ...args.envelopeAmounts,
+      transactions: receipts,
+      ltv: borrowReceipt.positionAfter?.ltv ?? undefined,
+      healthFactor: borrowReceipt.positionAfter?.healthFactor ?? undefined,
+      liquidationPriceFormatted:
+        borrowReceipt.positionAfter?.liquidationPriceFormatted,
+    })
+  } catch (err) {
+    rethrowAsCliError(err)
+  }
+}

--- a/packages/cli/src/commands/wallet/borrow/withdraw-collateral.ts
+++ b/packages/cli/src/commands/wallet/borrow/withdraw-collateral.ts
@@ -1,0 +1,42 @@
+import { CliError } from '@/output/errors.js'
+import { parseAmount } from '@/utils/parseAmount.js'
+
+import { runBorrowAction } from './runBorrowAction.js'
+
+export interface BorrowWithdrawCollateralFlags {
+  market: string
+  amount?: string
+  max?: boolean
+}
+
+/**
+ * @description Handler for `actions wallet borrow withdraw-collateral --market <name> (--amount <n> | --max)`. Pulls collateral back to the wallet. `--max` resolves to the live collateral balance at dispatch time so dust from interest accrual is not left behind. The CLI enforces the xor at runtime because commander hands the handler a loosely-typed object.
+ * @param flags - Commander-parsed options.
+ * @throws `CliError` with code `validation` when both `--amount` and `--max` are set or when neither is.
+ */
+export async function runWalletBorrowWithdrawCollateral(
+  flags: BorrowWithdrawCollateralFlags,
+): Promise<void> {
+  const isMax = flags.max === true
+  if (isMax && flags.amount !== undefined) {
+    throw new CliError(
+      'validation',
+      'Pass either --amount or --max, not both',
+      { amount: flags.amount, max: true },
+    )
+  }
+  if (!isMax && flags.amount === undefined) {
+    throw new CliError('validation', 'Either --amount or --max is required')
+  }
+  const amount = isMax ? undefined : parseAmount(flags.amount as string)
+  await runBorrowAction({
+    action: 'withdrawCollateral',
+    marketName: flags.market,
+    buildAndDispatch: async (wallet, market) =>
+      wallet.borrow.withdrawCollateral({
+        market,
+        amount: isMax ? { max: true } : { amount: amount as number },
+      }),
+    envelopeAmounts: { collateralAmount: isMax ? 'max' : amount },
+  })
+}

--- a/packages/cli/src/commands/wallet/borrow/withdraw-collateral.ts
+++ b/packages/cli/src/commands/wallet/borrow/withdraw-collateral.ts
@@ -1,7 +1,8 @@
-import { CliError } from '@/output/errors.js'
-import { parseAmount } from '@/utils/parseAmount.js'
-
-import { runBorrowAction } from './runBorrowAction.js'
+import {
+  amountOrMaxToEnvelope,
+  resolveAmountOrMax,
+  runBorrowAction,
+} from './runBorrowAction.js'
 
 export interface BorrowWithdrawCollateralFlags {
   market: string
@@ -10,33 +11,27 @@ export interface BorrowWithdrawCollateralFlags {
 }
 
 /**
- * @description Handler for `actions wallet borrow withdraw-collateral --market <name> (--amount <n> | --max)`. Pulls collateral back to the wallet. `--max` resolves to the live collateral balance at dispatch time so dust from interest accrual is not left behind. The CLI enforces the xor at runtime because commander hands the handler a loosely-typed object.
+ * @description Handler for `actions wallet borrow withdraw-collateral --market <name> (--amount <n> | --max)`. Pulls collateral back to the wallet. `--max` resolves to the live collateral balance at dispatch time so dust from interest accrual is not left behind. Mutex enforcement happens inside `resolveAmountOrMax`.
  * @param flags - Commander-parsed options.
  * @throws `CliError` with code `validation` when both `--amount` and `--max` are set or when neither is.
  */
 export async function runWalletBorrowWithdrawCollateral(
   flags: BorrowWithdrawCollateralFlags,
 ): Promise<void> {
-  const isMax = flags.max === true
-  if (isMax && flags.amount !== undefined) {
-    throw new CliError(
-      'validation',
-      'Pass either --amount or --max, not both',
-      { amount: flags.amount, max: true },
-    )
-  }
-  if (!isMax && flags.amount === undefined) {
-    throw new CliError('validation', 'Either --amount or --max is required')
-  }
-  const amount = isMax ? undefined : parseAmount(flags.amount as string)
+  const amount = resolveAmountOrMax(
+    {
+      amountFlag: '--amount',
+      maxFlag: '--max',
+      raw: flags.amount,
+      isMax: flags.max === true,
+    },
+    true,
+  )
   await runBorrowAction({
     action: 'withdrawCollateral',
     marketName: flags.market,
     buildAndDispatch: async (wallet, market) =>
-      wallet.borrow.withdrawCollateral({
-        market,
-        amount: isMax ? { max: true } : { amount: amount as number },
-      }),
-    envelopeAmounts: { collateralAmount: isMax ? 'max' : amount },
+      wallet.borrow.withdrawCollateral({ market, amount }),
+    envelopeAmounts: { collateralAmount: amountOrMaxToEnvelope(amount) },
   })
 }

--- a/packages/cli/src/commands/wallet/index.ts
+++ b/packages/cli/src/commands/wallet/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 
 import { runWalletAddress } from '@/commands/wallet/address.js'
 import { runWalletBalance } from '@/commands/wallet/balance.js'
+import { walletBorrowCommand } from '@/commands/wallet/borrow/index.js'
 import { walletLendCommand } from '@/commands/wallet/lend/index.js'
 import { walletSwapCommand } from '@/commands/wallet/swap/index.js'
 import { CHAIN_EXAMPLES } from '@/resolvers/chains.js'
@@ -32,6 +33,7 @@ export function walletCommand(): Command {
     )
     .action(runWalletBalance)
   command.addCommand(walletLendCommand())
+  command.addCommand(walletBorrowCommand())
   command.addCommand(walletSwapCommand())
   return command
 }

--- a/packages/cli/src/commands/wallet/lend/runLendAction.ts
+++ b/packages/cli/src/commands/wallet/lend/runLendAction.ts
@@ -1,14 +1,11 @@
-import {
-  APPROVAL_MODES,
-  type ApprovalMode,
-  type LendAction,
-} from '@eth-optimism/actions-sdk'
+import { type LendAction } from '@eth-optimism/actions-sdk'
 
 import { walletContext } from '@/context/walletContext.js'
 import { CliError, rethrowAsCliError } from '@/output/errors.js'
 import { printOutput } from '@/output/printOutput.js'
 import { configuredMarkets, resolveMarket } from '@/resolvers/markets.js'
 import { parseAmount } from '@/utils/parseAmount.js'
+import { parseApprovalMode } from '@/utils/parseApprovalMode.js'
 import { ensureOnchainSuccess, toReceiptArray } from '@/utils/receipts.js'
 
 import { requireLendCapability } from './requireLendCapability.js'
@@ -26,18 +23,6 @@ export interface LendOpenFlags {
 export type LendCloseFlags =
   | { market: string; amount: string; max?: never }
   | { market: string; amount?: never; max: true }
-
-function parseApprovalMode(raw: string | undefined): ApprovalMode | undefined {
-  if (raw === undefined) return undefined
-  if ((APPROVAL_MODES as readonly string[]).includes(raw)) {
-    return raw as ApprovalMode
-  }
-  throw new CliError(
-    'validation',
-    `Invalid --approval-mode: ${raw} (expected ${APPROVAL_MODES.join(' or ')})`,
-    { approvalMode: raw },
-  )
-}
 
 /**
  * @description Shared backbone for the wallet-scoped lend write commands. `open` and `close` are mechanically identical apart from which `wallet.lend.*Position` method is called, the literal `action` value embedded in the output envelope, and the action-specific flags (`open` consumes `--approval-mode`; `close` accepts `--max`). This helper resolves the market, validates the amount, dispatches to the SDK, normalises the receipt array, raises on revert, and emits a `LendActionDoc` envelope.

--- a/packages/cli/src/demo/config.ts
+++ b/packages/cli/src/demo/config.ts
@@ -6,7 +6,11 @@ import {
 } from '@eth-optimism/actions-sdk'
 
 import { getDemoChains } from '@/demo/chains.js'
-import { AaveETH, GauntletUSDCDemo } from '@/demo/markets.js'
+import {
+  AaveETH,
+  GauntletUSDCDemo,
+  MorphoUSDCBorrowDemo,
+} from '@/demo/markets.js'
 
 /**
  * @description Returns the baked demo `NodeActionsConfig` the CLI boots
@@ -28,6 +32,9 @@ export function getDemoConfig(): NodeActionsConfig<never> {
     lend: {
       morpho: { marketAllowlist: [GauntletUSDCDemo] },
       aave: { marketAllowlist: [AaveETH] },
+    },
+    borrow: {
+      morpho: { marketAllowlist: [MorphoUSDCBorrowDemo] },
     },
     swap: {
       uniswap: {

--- a/packages/cli/src/demo/markets.ts
+++ b/packages/cli/src/demo/markets.ts
@@ -1,7 +1,9 @@
 import {
+  type BorrowMarketConfig,
   ETH,
   getAssetAddress,
   type LendMarketConfig,
+  OP_DEMO,
   USDC_DEMO,
   WETH,
 } from '@eth-optimism/actions-sdk'
@@ -31,4 +33,32 @@ export const AaveETH: LendMarketConfig = {
   name: 'Aave ETH',
   asset: ETH,
   lendProvider: 'aave',
+}
+
+/**
+ * @description Morpho Blue market on Base Sepolia used for borrow demos.
+ * `marketId` is the keccak256 of `marketParams` (loanToken, collateralToken,
+ * oracle, irm, lltv). Mirrored from `packages/demo/backend/src/config/markets.ts`
+ * so the CLI operates against the same demo market the backend does. Collateral
+ * is the Gauntlet USDC vault share (a Morpho vault token), and the borrow asset
+ * is OP_DEMO; `lendProvider: 'morpho'` is informational so frontends can wire
+ * the supply leg through the same protocol.
+ */
+export const MorphoUSDCBorrowDemo: BorrowMarketConfig = {
+  kind: 'morpho-blue',
+  marketId:
+    '0x7dc82421423b50debf8c1f9f967f34367e0fb7bcdb1bda0cef27c319d89cd12f',
+  chainId: baseSepolia.id,
+  name: 'Demo dUSDC / OP',
+  collateralAsset: USDC_DEMO,
+  borrowAsset: OP_DEMO,
+  borrowProvider: 'morpho',
+  lendProvider: 'morpho',
+  marketParams: {
+    loanToken: '0xD6169405013E92387b78457Fa77d377cE8cD3EE8',
+    collateralToken: '0x018e22BBC6eB3daCfd151d1Cc4Dc72f6337B3eA1',
+    oracle: '0xB31E326bF4BdB5Ab98eF19C16dd420C8d6176e86',
+    irm: '0x46415998764C29aB2a25CbeA6254146D50D22687',
+    lltv: 860000000000000000n,
+  },
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command, Help } from 'commander'
 import pico from 'picocolors'
 
 import { runAssets } from '@/commands/actions/assets.js'
+import { borrowCommand } from '@/commands/actions/borrow/index.js'
 import { runChains } from '@/commands/actions/chains.js'
 import { lendCommand } from '@/commands/actions/lend/index.js'
 import { swapCommand } from '@/commands/actions/swap/index.js'
@@ -52,6 +53,7 @@ program
   .action(runChains)
 
 program.addCommand(lendCommand())
+program.addCommand(borrowCommand())
 program.addCommand(swapCommand())
 program.addCommand(walletCommand())
 

--- a/packages/cli/src/output/printOutput.ts
+++ b/packages/cli/src/output/printOutput.ts
@@ -1,5 +1,10 @@
 import type {
   Asset,
+  BorrowAction,
+  BorrowMarket,
+  BorrowMarketId,
+  BorrowMarketPosition,
+  BorrowProviderName,
   LendAction,
   LendMarket,
   LendMarketPosition,
@@ -42,6 +47,44 @@ export interface LendActionDoc {
   transactions: readonly WalletTransactionReceipt[]
 }
 
+/**
+ * @description Per-leg amounts embedded in a `BorrowActionDoc`. `'max'` is
+ * surfaced verbatim (the SDK's full-balance path) so agents can tell a
+ * literal 0 borrow from a max-resolve. Both legs are optional because every
+ * verb only touches one or two of them: `repay` reports `borrowAmount`,
+ * `deposit-collateral` reports `collateralAmount`, `open` / `close` report
+ * both.
+ */
+export interface BorrowEnvelopeAmounts {
+  borrowAmount?: number | 'max'
+  collateralAmount?: number | 'max'
+}
+
+/**
+ * @description Output envelope for the wallet-scoped borrow write verbs. The
+ * `market.marketId` field is the full `BorrowMarketId` discriminated union
+ * (not just a hex string) so a future second provider variant (Aave, Comet)
+ * with different discriminator fields surfaces without breaking consumers.
+ * `positionAfter` highlights (`ltv`, `healthFactor`,
+ * `liquidationPriceFormatted`) are decorated onto the envelope so an agent
+ * has health context without a second `getPosition` call; they're optional
+ * because the SDK only surfaces them when the provider produced a
+ * `positionAfter` snapshot.
+ */
+export interface BorrowActionDoc extends BorrowEnvelopeAmounts {
+  action: BorrowAction
+  market: {
+    name: string
+    marketId: BorrowMarketId
+    chainId: SupportedChainId
+    provider: BorrowProviderName
+  }
+  transactions: readonly WalletTransactionReceipt[]
+  ltv?: number | null
+  healthFactor?: number | null
+  liquidationPriceFormatted?: string
+}
+
 export interface SwapExecuteDoc {
   action: 'execute'
   assetIn: { symbol: string }
@@ -64,6 +107,10 @@ interface Printers {
   lendMarkets: readonly LendMarket[]
   lendMarket: LendMarket
   lendPosition: LendMarketPosition
+  borrowAction: BorrowActionDoc
+  borrowMarkets: readonly BorrowMarket[]
+  borrowMarket: BorrowMarket
+  borrowPosition: BorrowMarketPosition
   swapMarkets: readonly SwapMarket[]
   swapMarket: SwapMarket
   swapQuote: SwapQuote
@@ -172,6 +219,81 @@ function formatLendPosition(p: LendMarketPosition): void {
   )
 }
 
+const BORROW_ACTION_VERBS = {
+  open: 'opened',
+  close: 'closed',
+  depositCollateral: 'deposited collateral on',
+  withdrawCollateral: 'withdrew collateral from',
+  repay: 'repaid',
+} as const satisfies Record<BorrowActionDoc['action'], string>
+
+function fmtAmount(value: number | 'max' | undefined): string | undefined {
+  if (value === undefined) return undefined
+  return value === 'max' ? 'max' : String(value)
+}
+
+function formatBorrowAction(doc: BorrowActionDoc): void {
+  const verb = BORROW_ACTION_VERBS[doc.action]
+  const parts: string[] = []
+  const borrow = fmtAmount(doc.borrowAmount)
+  const collateral = fmtAmount(doc.collateralAmount)
+  if (borrow !== undefined) parts.push(`borrow=${borrow}`)
+  if (collateral !== undefined) parts.push(`collateral=${collateral}`)
+  const amounts = parts.length > 0 ? ` (${parts.join(' ')})` : ''
+  writeLine(
+    `${verb} ${doc.market.name}${amounts} on ${doc.market.provider} (chain ${doc.market.chainId})`,
+  )
+  if (
+    doc.ltv !== undefined ||
+    doc.healthFactor !== undefined ||
+    doc.liquidationPriceFormatted !== undefined
+  ) {
+    const ltv = doc.ltv == null ? 'n/a' : doc.ltv.toFixed(4)
+    const hf = doc.healthFactor == null ? 'n/a' : doc.healthFactor.toFixed(4)
+    const liq = doc.liquidationPriceFormatted ?? 'n/a'
+    writeLine(`  ltv=${ltv} healthFactor=${hf} liquidationPrice=${liq}`)
+  }
+  formatReceiptList(doc.transactions)
+}
+
+function formatBorrowMarket(m: BorrowMarket): void {
+  const collat = m.collateralAsset.metadata.symbol
+  const borrow = m.borrowAsset.metadata.symbol
+  writeLine(
+    `${m.name}  ${collat}/${borrow} chain=${m.marketId.chainId} borrowApy=${(m.borrowApy * 100).toFixed(2)}%`,
+  )
+  writeLine(
+    `  marketId=${m.marketId.marketId} maxLtv=${(m.maxLtv * 100).toFixed(2)}% liquidationBonus=${(m.liquidationBonus * 100).toFixed(2)}%`,
+  )
+  writeLine(
+    `  totalBorrowed=${m.totalBorrowed} totalCollateral=${m.totalCollateral}`,
+  )
+}
+
+function formatBorrowMarkets(markets: readonly BorrowMarket[]): void {
+  if (markets.length === 0) {
+    writeLine('(no markets)')
+    return
+  }
+  for (const m of markets) formatBorrowMarket(m)
+}
+
+function formatBorrowPosition(p: BorrowMarketPosition): void {
+  const collat = p.collateralAsset.metadata.symbol
+  const borrow = p.borrowAsset.metadata.symbol
+  writeLine(
+    `position: collateral=${p.collateralAmountFormatted} ${collat} debt=${p.borrowAmountFormatted} ${borrow} chain=${p.marketId.chainId}`,
+  )
+  const ltv = p.ltv == null ? 'n/a' : p.ltv.toFixed(4)
+  const hf = p.healthFactor == null ? 'n/a' : p.healthFactor.toFixed(4)
+  writeLine(
+    `  ltv=${ltv} maxLtv=${p.maxLtv.toFixed(4)} healthFactor=${hf} liquidationPrice=${p.liquidationPriceFormatted}`,
+  )
+  writeLine(
+    `  borrowApy=${(p.borrowApy * 100).toFixed(2)}% liquidationBonus=${(p.liquidationBonus * 100).toFixed(2)}%`,
+  )
+}
+
 function formatSwapMarket(m: SwapMarket): void {
   const [a, b] = m.assets
   writeLine(
@@ -223,6 +345,10 @@ const TEXT_FORMATTERS: {
   lendMarkets: formatLendMarkets,
   lendMarket: formatLendMarket,
   lendPosition: formatLendPosition,
+  borrowAction: formatBorrowAction,
+  borrowMarkets: formatBorrowMarkets,
+  borrowMarket: formatBorrowMarket,
+  borrowPosition: formatBorrowPosition,
   swapMarkets: formatSwapMarkets,
   swapMarket: formatSwapMarket,
   swapQuote: formatSwapQuote,

--- a/packages/cli/src/resolvers/__tests__/borrowMarkets.test.ts
+++ b/packages/cli/src/resolvers/__tests__/borrowMarkets.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDemoConfig } from '@/demo/config.js'
+import { CliError } from '@/output/errors.js'
+import {
+  configuredBorrowMarkets,
+  resolveBorrowMarket,
+} from '@/resolvers/borrowMarkets.js'
+
+const markets = configuredBorrowMarkets(getDemoConfig())
+
+describe('resolveBorrowMarket', () => {
+  it('matches by exact .name', () => {
+    const market = resolveBorrowMarket('Demo dUSDC / OP', markets)
+    expect(market.name).toBe('Demo dUSDC / OP')
+    expect(market.borrowProvider).toBe('morpho')
+  })
+
+  it('matches case-insensitively and ignores hyphens / spaces', () => {
+    expect(resolveBorrowMarket('demo-dusdc-op', markets).name).toBe(
+      'Demo dUSDC / OP',
+    )
+    expect(resolveBorrowMarket('DEMODUSDC/OP', markets).name).toBe(
+      'Demo dUSDC / OP',
+    )
+  })
+
+  it('throws CliError(validation) with allowed list on miss', () => {
+    try {
+      resolveBorrowMarket('does-not-exist', markets)
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/Unknown borrow market/)
+      const details = (err as CliError).details as {
+        allowed: Array<{
+          name: string
+          chainId: number
+          collateral: string
+          borrow: string
+        }>
+      }
+      expect(details.allowed.map((m) => m.name)).toEqual(['Demo dUSDC / OP'])
+      for (const m of details.allowed) {
+        expect(typeof m.chainId).toBe('number')
+        expect(typeof m.collateral).toBe('string')
+        expect(typeof m.borrow).toBe('string')
+      }
+    }
+  })
+
+  it('returns a market entry that carries the full discriminated config', () => {
+    const m = resolveBorrowMarket('Demo dUSDC / OP', markets)
+    expect(m.kind).toBe('morpho-blue')
+    expect(m.marketId).toMatch(/^0x[a-fA-F0-9]{64}$/)
+    expect(typeof m.chainId).toBe('number')
+    expect(m.collateralAsset.metadata.symbol).toBe('USDC_DEMO')
+    expect(m.borrowAsset.metadata.symbol).toBe('OP_DEMO')
+    expect(m.marketParams.lltv).toBe(860000000000000000n)
+  })
+})
+
+describe('configuredBorrowMarkets', () => {
+  it('flattens every provider allowlist', () => {
+    const all = configuredBorrowMarkets(getDemoConfig())
+    expect(all.map((m) => m.name)).toEqual(['Demo dUSDC / OP'])
+  })
+
+  it('returns an empty array when config.borrow is omitted', () => {
+    const cfg = { ...getDemoConfig(), borrow: undefined }
+    expect(configuredBorrowMarkets(cfg)).toEqual([])
+  })
+})
+
+describe('resolveBorrowMarket collision behaviour', () => {
+  it('throws CliError(validation) with matches list when two providers normalise to the same name', () => {
+    const dup: typeof markets = [
+      { ...markets[0]!, name: 'Dup' },
+      { ...markets[0]!, name: 'dup' },
+    ]
+    try {
+      resolveBorrowMarket('dup', dup)
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).code).toBe('validation')
+      expect((err as CliError).message).toMatch(/Ambiguous/)
+      const details = (err as CliError).details as {
+        matches: Array<{ provider: string }>
+      }
+      expect(details.matches).toHaveLength(2)
+    }
+  })
+})

--- a/packages/cli/src/resolvers/borrowMarkets.ts
+++ b/packages/cli/src/resolvers/borrowMarkets.ts
@@ -1,0 +1,68 @@
+import {
+  BORROW_PROVIDER_NAMES,
+  type BorrowMarketConfig,
+  type NodeActionsConfig,
+} from '@eth-optimism/actions-sdk'
+
+import { CliError } from '@/output/errors.js'
+
+function normalize(value: string): string {
+  // Strip whitespace, hyphens, and slashes. Diverges from `resolveMarket`'s
+  // `[\s-]` because borrow market names commonly contain a `/` separator
+  // between collateral and borrow assets (e.g. "Demo dUSDC / OP") and the
+  // acceptance criteria require `demo-dusdc-op` to resolve to that market.
+  return value.toLowerCase().replace(/[\s/-]/g, '')
+}
+
+/**
+ * @description Returns every borrow market allowlisted across the configured borrow providers. The SDK does not ship a `getBorrowMarketAllowlist` helper, so the CLI flattens `config.borrow` itself by iterating `BORROW_PROVIDER_NAMES`. This keeps the resolver provider-agnostic when new borrow providers join the SDK constant. Mirrors `configuredMarkets` in `resolvers/markets.ts` so call sites read symmetrically.
+ * @param config - Resolved CLI config.
+ * @returns Flat array of every allowlisted borrow market across all providers.
+ */
+export function configuredBorrowMarkets(
+  config: NodeActionsConfig<never>,
+): readonly BorrowMarketConfig[] {
+  return BORROW_PROVIDER_NAMES.flatMap(
+    (name) => config.borrow?.[name]?.marketAllowlist ?? [],
+  )
+}
+
+/**
+ * @description Resolves a `--market <name>` flag value to the matching `BorrowMarketConfig` entry from a caller-supplied allowlist. Match is case-insensitive and ignores whitespace / hyphens, so `Demo dUSDC / OP`, `demo-dusdc-op`, and `DemoDusdcOp` all resolve to the same market. Throws `CliError('validation')` on miss with an `allowed` list including collateral/borrow asset symbols. Mirrors `resolveMarket` retyped to the borrow shape; the borrow market config carries `collateralAsset` / `borrowAsset` instead of a single `asset`.
+ * @param name - User-provided market name from CLI argv.
+ * @param allow - Borrow market allowlist to search.
+ * @returns The matching borrow market entry (carries `kind`, `marketId`, `chainId`, `collateralAsset`, `borrowAsset`, `borrowProvider`, `marketParams`).
+ * @throws `CliError` with code `validation` when no market matches or when two providers normalize to the same name.
+ */
+export function resolveBorrowMarket(
+  name: string,
+  allow: readonly BorrowMarketConfig[],
+): BorrowMarketConfig {
+  const target = normalize(name)
+  const matches = allow.filter((m) => normalize(m.name) === target)
+  if (matches.length === 0) {
+    throw new CliError('validation', `Unknown borrow market: ${name}`, {
+      market: name,
+      allowed: allow.map((m) => ({
+        name: m.name,
+        chainId: m.chainId,
+        collateral: m.collateralAsset.metadata.symbol,
+        borrow: m.borrowAsset.metadata.symbol,
+      })),
+    })
+  }
+  if (matches.length > 1) {
+    // Two providers list a market that normalises to the same key. Surface the
+    // ambiguity so the operator fixes the config instead of getting a silent
+    // first-iteration pick.
+    throw new CliError('validation', `Ambiguous borrow market: ${name}`, {
+      market: name,
+      matches: matches.map((m) => ({
+        name: m.name,
+        chainId: m.chainId,
+        provider: m.borrowProvider,
+      })),
+    })
+  }
+  return matches[0] as BorrowMarketConfig
+}

--- a/packages/cli/src/resolvers/borrowMarkets.ts
+++ b/packages/cli/src/resolvers/borrowMarkets.ts
@@ -5,14 +5,7 @@ import {
 } from '@eth-optimism/actions-sdk'
 
 import { CliError } from '@/output/errors.js'
-
-function normalize(value: string): string {
-  // Strip whitespace, hyphens, and slashes. Diverges from `resolveMarket`'s
-  // `[\s-]` because borrow market names commonly contain a `/` separator
-  // between collateral and borrow assets (e.g. "Demo dUSDC / OP") and the
-  // acceptance criteria require `demo-dusdc-op` to resolve to that market.
-  return value.toLowerCase().replace(/[\s/-]/g, '')
-}
+import { normalizeMarketName } from '@/resolvers/normalize.js'
 
 /**
  * @description Returns every borrow market allowlisted across the configured borrow providers. The SDK does not ship a `getBorrowMarketAllowlist` helper, so the CLI flattens `config.borrow` itself by iterating `BORROW_PROVIDER_NAMES`. This keeps the resolver provider-agnostic when new borrow providers join the SDK constant. Mirrors `configuredMarkets` in `resolvers/markets.ts` so call sites read symmetrically.
@@ -38,8 +31,8 @@ export function resolveBorrowMarket(
   name: string,
   allow: readonly BorrowMarketConfig[],
 ): BorrowMarketConfig {
-  const target = normalize(name)
-  const matches = allow.filter((m) => normalize(m.name) === target)
+  const target = normalizeMarketName(name)
+  const matches = allow.filter((m) => normalizeMarketName(m.name) === target)
   if (matches.length === 0) {
     throw new CliError('validation', `Unknown borrow market: ${name}`, {
       market: name,

--- a/packages/cli/src/resolvers/markets.ts
+++ b/packages/cli/src/resolvers/markets.ts
@@ -5,10 +5,7 @@ import {
 } from '@eth-optimism/actions-sdk'
 
 import { CliError } from '@/output/errors.js'
-
-function normalize(value: string): string {
-  return value.toLowerCase().replace(/[\s-]/g, '')
-}
+import { normalizeMarketName } from '@/resolvers/normalize.js'
 
 /**
  * @description Returns every market allowlisted across the configured lend providers. Thin wrapper around `getLendMarketAllowlist(config.lend)`; kept here so CLI call sites read `configuredMarkets(config)` symmetrically with `configuredAssets(config)` / `configuredChains(config)`.
@@ -32,8 +29,8 @@ export function resolveMarket(
   name: string,
   allow: readonly LendMarketConfig[],
 ): LendMarketConfig {
-  const target = normalize(name)
-  const matches = allow.filter((m) => normalize(m.name) === target)
+  const target = normalizeMarketName(name)
+  const matches = allow.filter((m) => normalizeMarketName(m.name) === target)
   if (matches.length === 0) {
     throw new CliError('validation', `Unknown market: ${name}`, {
       market: name,

--- a/packages/cli/src/resolvers/normalize.ts
+++ b/packages/cli/src/resolvers/normalize.ts
@@ -1,0 +1,8 @@
+/**
+ * @description Normalises a market name for case- and punctuation-insensitive matching. Lowercases, then strips whitespace, hyphens, and slashes so `Gauntlet USDC`, `gauntlet-usdc`, `GauntletUSDC`, `Demo dUSDC / OP`, and `demo-dusdc-op` collapse to the same key. Used by both `resolveMarket` (lend) and `resolveBorrowMarket` so the matching rule lives in one place. Stripping `/` is harmless for lend market names (none contain a slash today) and required for the borrow demo market `Demo dUSDC / OP`.
+ * @param value - Market name as it appears in config or argv.
+ * @returns Normalised key for direct equality comparison.
+ */
+export function normalizeMarketName(value: string): string {
+  return value.toLowerCase().replace(/[\s/-]/g, '')
+}

--- a/packages/cli/src/utils/__tests__/receipts.test.ts
+++ b/packages/cli/src/utils/__tests__/receipts.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { CliError } from '@/output/errors.js'
+import { ensureOnchainSuccess } from '@/utils/receipts.js'
+
+const ok = (transactionHash: string) => ({
+  transactionHash,
+  status: 'success' as const,
+  blockNumber: 1n,
+  gasUsed: 21000n,
+})
+
+const reverted = (transactionHash: string) => ({
+  transactionHash,
+  status: 'reverted' as const,
+  blockNumber: 2n,
+  gasUsed: 21000n,
+})
+
+const userOpFailure = (userOpHash: string) => ({
+  success: false as const,
+  userOpHash,
+})
+
+describe('ensureOnchainSuccess', () => {
+  it('returns without throwing when every leg succeeded', () => {
+    expect(() =>
+      ensureOnchainSuccess([ok('0xa'), ok('0xb')] as never),
+    ).not.toThrow()
+  })
+
+  it('throws CliError(onchain) carrying the full receipts array on a batched failure', () => {
+    // Sequential EOA bundle: approve + supplyCollateral mined, borrow reverts.
+    const receipts = [ok('0xapprove'), ok('0xsupply'), reverted('0xborrow')]
+    try {
+      ensureOnchainSuccess(receipts as never)
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      const cliErr = err as CliError
+      expect(cliErr.code).toBe('onchain')
+      expect(cliErr.message).toBe('Transaction status: reverted')
+      const details = cliErr.details as Record<string, unknown>
+      // The failing leg's own diagnostics are preserved...
+      expect(details.transactionHash).toBe('0xborrow')
+      // ...and the already-mined legs are retained, not dropped.
+      expect(details.transactions).toEqual(receipts)
+      expect(
+        (details.transactions as Array<{ transactionHash: string }>).map(
+          (r) => r.transactionHash,
+        ),
+      ).toEqual(['0xapprove', '0xsupply', '0xborrow'])
+    }
+  })
+
+  it('includes the receipts array for a failed UserOperation', () => {
+    const receipts = [userOpFailure('0xuserop')]
+    try {
+      ensureOnchainSuccess(receipts as never)
+      throw new Error('did not throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      const cliErr = err as CliError
+      expect(cliErr.code).toBe('onchain')
+      expect(cliErr.message).toBe('UserOperation failed')
+      const details = cliErr.details as Record<string, unknown>
+      expect(details.userOpHash).toBe('0xuserop')
+      expect(details.transactions).toEqual(receipts)
+    }
+  })
+})

--- a/packages/cli/src/utils/parseApprovalMode.ts
+++ b/packages/cli/src/utils/parseApprovalMode.ts
@@ -1,0 +1,23 @@
+import { APPROVAL_MODES, type ApprovalMode } from '@eth-optimism/actions-sdk'
+
+import { CliError } from '@/output/errors.js'
+
+/**
+ * @description Validates a raw `--approval-mode` argv value against the SDK's `APPROVAL_MODES` allowlist (`exact` | `max`). Returns `undefined` when the flag is omitted so the wallet's resolved default applies. Shared by every write verb that exposes `--approval-mode` (borrow `open` / `deposit-collateral` / `repay`, lend `open`, and swap `execute`); they all carry identical semantics, so the check lives here rather than being copied per command.
+ * @param raw - The argv value as a string, or `undefined` when the flag is unset.
+ * @returns The validated `ApprovalMode`, or `undefined` when `raw` is `undefined`.
+ * @throws `CliError` with code `validation` when `raw` is set but is not a recognised approval mode.
+ */
+export function parseApprovalMode(
+  raw: string | undefined,
+): ApprovalMode | undefined {
+  if (raw === undefined) return undefined
+  if ((APPROVAL_MODES as readonly string[]).includes(raw)) {
+    return raw as ApprovalMode
+  }
+  throw new CliError(
+    'validation',
+    `Invalid --approval-mode: ${raw} (expected ${APPROVAL_MODES.join(' or ')})`,
+    { approvalMode: raw },
+  )
+}

--- a/packages/cli/src/utils/receipts.ts
+++ b/packages/cli/src/utils/receipts.ts
@@ -50,14 +50,19 @@ function receiptFailure(r: WalletTransactionReceipt): CliError {
 }
 
 /**
- * @description Inspects receipts for failure markers and raises `CliError('onchain')` when any leg failed or carries an unrecognised shape. Default-deny: anything that is not an explicit success (`status === 'success'` for EOA, `success === true` for UserOp) is treated as failure, so a malformed receipt from a misbehaving RPC cannot be silently reported as success.
+ * @description Inspects receipts for failure markers and raises `CliError('onchain')` when any leg failed or carries an unrecognised shape. Default-deny: anything that is not an explicit success (`status === 'success'` for EOA, `success === true` for UserOp) is treated as failure, so a malformed receipt from a misbehaving RPC cannot be silently reported as success. The thrown error carries the full `receipts` array under `details.transactions` (alongside the failing leg's own diagnostics) so a batched failure does not drop the already-mined legs: on a sequential EOA bundle like `[approve, supplyCollateral, borrow]`, a reverted `borrow` still surfaces the mined `approve` hash and the gas it spent.
  * @param receipts - Receipts returned by the SDK.
- * @throws `CliError` with code `onchain` on revert, UserOp failure, or unrecognised shape.
+ * @throws `CliError` with code `onchain` on revert, UserOp failure, or unrecognised shape; `details.transactions` holds every receipt in the batch.
  */
 export function ensureOnchainSuccess(
   receipts: readonly WalletTransactionReceipt[],
 ): void {
   for (const r of receipts) {
-    if (isReceiptFailure(r)) throw receiptFailure(r)
+    if (!isReceiptFailure(r)) continue
+    const failure = receiptFailure(r)
+    throw new CliError('onchain', failure.message, {
+      ...(failure.details as Record<string, unknown>),
+      transactions: receipts,
+    })
   }
 }


### PR DESCRIPTION
## Summary 

Adds the borrow namespace to the CLI on top of the SDK borrow surface that shipped in #458: read-only `actions borrow markets` / `market` / `position`, and wallet-scoped `wallet borrow open` / `close` / `deposit-collateral` / `withdraw-collateral` / `repay` / `position`. 257/257 tests pass.

## Read commands (no PRIVATE_KEY)
- `actions borrow markets [--collateral <symbol>] [--borrow-asset <symbol>] [--chain <name> | --chain-id <id>]`
- `actions borrow market --market <name>`
- `actions borrow position --market <name> --wallet <address>` — reads any wallet's position; `--wallet` is validated via viem `isAddress` and forwarded checksummed (`getAddress`).

## Wallet commands (require PRIVATE_KEY)
- `actions wallet borrow open --market <name> --borrow-amount <n> [--collateral-amount <n>] [--approval-mode <exact|max>]` — no `--max` (open path only accepts strict amounts)
- `actions wallet borrow close --market <name> [--borrow-amount <n> | --borrow-max] [--collateral-amount <n> | --collateral-max]` — per-leg xor; borrow leg required
- `actions wallet borrow deposit-collateral --market <name> --amount <n> [--approval-mode <exact|max>]`
- `actions wallet borrow withdraw-collateral --market <name> (--amount <n> | --max)`
- `actions wallet borrow repay --market <name> (--amount <n> | --max) [--approval-mode <exact|max>]`
- `actions wallet borrow position --market <name>` — uses `wallet.address` (no `--wallet` flag)

## SDK -> CLI

```
actions.borrow.getMarkets({collateralAsset?, borrowAsset?, chainId?}) -> actions borrow markets ...
actions.borrow.getMarket(market)                                      -> actions borrow market --market <name>
actions.borrow.getPosition({marketId, walletAddress})                 -> actions borrow position --market <name> --wallet <addr>
wallet.borrow.openPosition({market, borrowAmount, collateralAmount?}) -> actions wallet borrow open ...
wallet.borrow.closePosition({market, borrowAmount, collateralAmount?}) -> actions wallet borrow close ...
wallet.borrow.depositCollateral({market, amount, approvalMode?})      -> actions wallet borrow deposit-collateral ...
wallet.borrow.withdrawCollateral({market, amount})                    -> actions wallet borrow withdraw-collateral ...
wallet.borrow.repay({market, amount, approvalMode?})                  -> actions wallet borrow repay ...
```

The resolved `BorrowMarketConfig` is passed straight to the SDK wherever a `BorrowMarketId` or `market` is expected (it's structurally a superset of `BorrowMarketId`). No Morpho-shaped literal is ever hand-built, so a future provider variant (Aave, Comet, ...) with different discriminator fields lands without CLI changes.

## Validation & errors
- `--borrow-amount`/`--collateral-amount` are wrapped as `{ amount }` (#379 convention); `--*-max` becomes `{ max: true }`.
- Runtime mutex enforcement: `close` per-leg, `withdraw-collateral` and `repay` on `--amount` xor `--max`. Commander argv is loosely typed, so the runtime guards are still needed.
- `--approval-mode` validated against `APPROVAL_MODES`; only exposed on verbs that move tokens in (`open`, `deposit-collateral`, `repay`).
- `--wallet` on `actions borrow position` validated with viem `isAddress`; bad address -> `validation` exit 2.
- Reverts -> `code: "onchain"` exit 5; RPC failures -> retryable `network` exit 4; missing `config.borrow` -> `config` exit 3 (via `requireBorrowCapability`).

## Resolver
`packages/cli/src/resolvers/borrowMarkets.ts` is provider-agnostic: flattens `config.borrow` across `BORROW_PROVIDER_NAMES.flatMap((name) => config.borrow?.[name]?.marketAllowlist ?? [])`. There's no SDK `getBorrowMarketAllowlist` helper. Name normalization strips `[\s/-]` (vs lend's `[\s-]`) so the demo market `Demo dUSDC / OP` resolves from `demo-dusdc-op`.

## Output shape (write verbs)

```json
{
  "action": "open" | "close" | "depositCollateral" | "withdrawCollateral" | "repay",
  "market": {
    "name": "Demo dUSDC / OP",
    "marketId": { "kind": "morpho-blue", "marketId": "0x...", "chainId": 84532 },
    "chainId": 84532,
    "provider": "morpho"
  },
  "borrowAmount":     <number | "max">,
  "collateralAmount": <number | "max">,
  "transactions": [ { "transactionHash": "0x...", "status": "success", ... } ],
  "ltv": <number | null>,
  "healthFactor": <number | null>,
  "liquidationPriceFormatted": "<string>"
}
```

The market id field is the full `BorrowMarketId` union (not just a hex string) for forward-compat. `positionAfter` highlights (`ltv`, `healthFactor`, `liquidationPriceFormatted`) are decorated onto the envelope when the SDK supplies them so an agent gets health context without a second `getPosition` call; `ltv` and `healthFactor` are `null` when the action left no debt (divide-by-zero guard). `transactions` is normalised the same way as lend/swap via `toReceiptArray` (the SDK's `BorrowReceipt.receipt` covers single tx, batched EOA, and UserOp shapes).

`borrowMarkets` / `borrowMarket` / `borrowPosition` return the SDK shapes verbatim with bigints stringified.

## Demo config
`MorphoUSDCBorrowDemo` (mirrored from `packages/demo/backend/src/config/markets.ts`) added to `packages/cli/src/demo/markets.ts`; `borrow: { morpho: { marketAllowlist: [...] } }` wired into `getDemoConfig()`.

## SKILL.md
Borrow section added with NL -> command examples in the same voice as lend/swap.

## Screenshot

<img width="1648" height="1098" alt="image" src="https://github.com/user-attachments/assets/91933a51-f2d7-48f4-98dc-7fdd75e9cefb" />

Closes #469.