### PR TITLE
ci: enable Project Zero dependency controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 # CI / CD pipelines
 .github/workflows/ @ethereum-optimism/ecosystem @ethereum-optimism/cloud-security
 .circleci/ @ethereum-optimism/ecosystem @ethereum-optimism/cloud-security
+/renovate.json @ethereum-optimism/ecosystem @ethereum-optimism/cloud-security
+/.github/dependency-review-config.yml @ethereum-optimism/ecosystem @ethereum-optimism/cloud-security
 
 # Container definitions
 Dockerfile @ethereum-optimism/ecosystem @ethereum-optimism/cloud-security

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,10 @@
+# Dependency Review exceptions for this repo.
+# Owned by @ethereum-optimism/cloud-security (see CODEOWNERS). fail-on-severity is
+# enforced centrally in the factory reusable workflow and cannot be weakened here.
+#
+# To waive a specific advisory a PR would otherwise be blocked on, add its GHSA id
+# under allow-ghsas with a justification, e.g.:
+#
+# allow-ghsas:
+#   - GHSA-xxxx-xxxx-xxxx  # <package> — why safe · owner · review-by 2026-Qx · <ticket>
+allow-ghsas: []

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,12 @@
+name: Dependency Review
+
+on: pull_request
+
+jobs:
+  dependency-review:
+    uses: ethereum-optimism/factory/.github/workflows/dependency-review.yaml@ed703fcc960cbe3f16c3844db11143a33b01b33b
+    with:
+      config-file: .github/dependency-review-config.yml
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,25 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level (debug|info|warn)."
+        type: string
+        default: "info"
+      dryRun:
+        description: "Dry run (no PRs)."
+        type: boolean
+        default: false
+
+jobs:
+  renovate:
+    uses: ethereum-optimism/factory/.github/workflows/renovate.yaml@fdcd6acceb0cbad90040e0be9f59a1ad60e65a86
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}
+      dryRun: ${{ inputs.dryRun || false }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ethereum-optimism/factory:renovate-config"]
+}


### PR DESCRIPTION
## Summary

- enable CVE-only Renovate through the shared factory configuration
- run Renovate daily with manual dry-run support
- add the shared dependency-review gate for pull requests
- add Cloud Security ownership for dependency automation configuration
- preserve the existing weekly Dependabot version updates

## Validation

- `actionlint .github/workflows/renovate.yaml .github/workflows/dependency-review.yml`
- `jq empty renovate.json`
- `git diff --check`
- verified the reusable workflows use the latest factory revisions

Closes https://github.com/ethereum-optimism/cloud-security/issues/375
