### PR TITLE
ci: automerge renovate security PRs and run hourly

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: "0 6 * * *" # daily 06:00 UTC
+    - cron: "17 * * * *" # hourly, staggered minute to avoid org-wide thundering herd
   workflow_dispatch:
     inputs:
       logLevel:

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ethereum-optimism/factory:renovate-config"]
+  "extends": [
+    "github>ethereum-optimism/factory:renovate-config"
+  ],
+  "vulnerabilityAlerts": {
+    "automerge": true
+  },
+  "automergeType": "pr",
+  "platformAutomerge": false,
+  "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## Summary

- enable automerge for Renovate security PRs via the local config override; the shared preset is CVE-only, so this applies exclusively to vulnerability fixes with green required checks
- move the Renovate schedule from daily to hourly (staggered minute per repository)
- `rebaseWhen: behind-base-branch` so stale fix branches refresh themselves instead of waiting on manual rebases

## Context

Same configuration already running in other Project Zero repositories; this closes the advisory-to-fix loop from up to a day to about an hour, with no change for regular version updates (which remain disabled).

Closes https://github.com/ethereum-optimism/cloud-security/issues/387
