### PR TITLE
ci: run renovate every 4 hours

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: "17 * * * *" # hourly, staggered minute to avoid org-wide thundering herd
+    - cron: "17 */4 * * *" # every 4 hours, staggered minute
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
Reduces the Renovate scan cadence from hourly to every 4 hours (staggered minutes preserved). Balances the advisory-to-fix loop against runner cost; security-fix behavior is otherwise unchanged.